### PR TITLE
Formatting fixes

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_library(littlec_ast STATIC lexer.cpp location.cpp nodes.cpp parser.cpp type.cpp)
+add_library(
+    littlec_ast STATIC lexer.cpp location.cpp nodes.cpp parser.cpp type.cpp
+)
 
-target_compile_options(littlec_ast PRIVATE -Og -fdata-sections -ffunction-sections)
+target_compile_options(
+    littlec_ast PRIVATE -Og -fdata-sections -ffunction-sections
+)
 target_link_libraries(littlec_ast littlec_utils)

--- a/src/ast/visitor_base.hpp
+++ b/src/ast/visitor_base.hpp
@@ -23,6 +23,6 @@ namespace ast {
         visitor_base() = default;
         // clang-format on
     };
-} // namespace visitor
+} // namespace ast
 
 #endif

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,4 +2,6 @@ add_library(littlec_utils STATIC execute.cpp string_utils.cpp)
 
 target_include_directories(littlec_utils PUBLIC .)
 
-target_compile_options(littlec_utils PRIVATE -Og -fdata-sections -ffunction-sections)
+target_compile_options(
+    littlec_utils PRIVATE -Og -fdata-sections -ffunction-sections
+)

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-clang-format $(git ls-files -- *.cpp *.hpp) -i -verbose -style=file -fallback-style=none
+clang-format $(find src -type f -name '*.[ch]pp' | tr '\n' ' ') -i -verbose -style=file -fallback-style=none
 cmake-format $(find . -type f -name 'CMakeLists.txt' | tr '\n' ' ') -i -c .cmake-format
 
 git diff

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 clang-format $(git ls-files -- *.cpp *.hpp) -i -verbose -style=file -fallback-style=none
-cmake-format $(git ls-files -- CMakeLists.txt */CMakeLists.txt) -i -c .cmake-format
+cmake-format $(find . -type f -name 'CMakeLists.txt' | tr '\n' ' ') -i -c .cmake-format
 
 git diff

--- a/tools/tidy.sh
+++ b/tools/tidy.sh
@@ -11,7 +11,7 @@ else
 fi
 
 flags=$(jq '.[]["command"]' compile_commands.json | sed 's:"/usr/bin/clang++ \(.*\) -o.*:\1:g' | head -n1)
-files=$(git ls-files -- 'src/*.cpp' 'src/*.hpp')
+files=$(find src -type f -name '*.[ch]pp')
 
 temp_dir=$(mktemp -d)
 


### PR DESCRIPTION
`git ls-files` appears to not support recursion.
`find` does, so it should be preferred for filtered queries. 