### PR TITLE
Type Context

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(littlec_type STATIC type.cpp)
+add_library(littlec_type STATIC type.cpp type_context.cpp)
 
 target_compile_options(
     littlec_type PRIVATE -Og -fdata-sections -ffunction-sections

--- a/src/ast/nodes.cpp
+++ b/src/ast/nodes.cpp
@@ -15,14 +15,6 @@ namespace ast {
         return operation::is_arithmetic(op);
     }
 
-    std::shared_ptr<ast::struct_type> struct_decl::type(const std::string & module_name) const {
-        std::vector<ast::struct_type::field_type> fields;
-        for (const auto & typed_id : this->fields) {
-            fields.emplace_back(typed_id.name(), typed_id.type());
-        }
-        return ast::struct_type::create(std::string{name}, module_name, std::move(fields));
-    }
-
     std::shared_ptr<ast::function_type> func_decl::func_type() const {
 
         std::vector<ast::type_ptr> param_types;

--- a/src/ast/nodes.cpp
+++ b/src/ast/nodes.cpp
@@ -15,11 +15,4 @@ namespace ast {
         return operation::is_arithmetic(op);
     }
 
-    std::shared_ptr<ast::function_type> func_decl::func_type() const {
-
-        std::vector<ast::type_ptr> param_types;
-        for (const auto & param : params) { param_types.push_back(param.type()); }
-
-        return ast::function_type::create(ret_type, std::move(param_types));
-    }
 } // namespace ast

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -261,19 +261,20 @@ std::unique_ptr<ast::struct_decl> parser::parse_struct_decl() {
         }
     }
 
-    {
+    auto struct_type = [&] {
         // Insert the new struct type into the ast type registry
         std::vector<ast::struct_type::field_type> struct_fields;
         struct_fields.reserve(fields.size());
         for (auto & typed_id : fields) {
             struct_fields.emplace_back(typed_id.name(), typed_id.type());
         }
-        assert(ast::struct_type::create(std::string{name.text}, module_name(),
-                                        std::move(struct_fields))
-               != nullptr);
-    }
+        return ty_context.create_type<ast::struct_type>(std::string{name.text}, module_name(),
+                                                        std::move(struct_fields));
+    }();
+    assert(struct_type != nullptr);
 
     auto decl = std::make_unique<ast::struct_decl>(std::move(name.text), std::move(fields));
+    decl->type = std::move(struct_type);
     decl->set_location(location);
     return decl;
 }

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -468,10 +468,10 @@ ast::type_ptr parser::parse_type() {
     }
     case lexer::token_type::amp:
         lex->next_token();
-        return ast::nonnullable_ptr_type::create(parse_type());
+        return ty_context.create_type<ast::nonnullable_ptr_type>(parse_type());
     case lexer::token_type::question:
         lex->next_token();
-        return ast::nullable_ptr_type::create(parse_type());
+        return ty_context.create_type<ast::nullable_ptr_type>(parse_type());
     default:
         error = "Expected a type. Found " + lex->peek_token().text;
         return nullptr;

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -210,7 +210,10 @@ std::unique_ptr<ast::func_decl> parser::parse_function() {
     auto func_decl
         = std::make_unique<ast::func_decl>(std::move(func_name_tok.text), std::move(body));
     func_decl->set_location(func_name_tok.location);
-    func_decl->ret_type = return_type;
+    std::vector<ast::type_ptr> arg_types;
+    for (auto & arg : args) { arg_types.push_back(arg.type()); }
+    func_decl->func_type
+        = ty_context.create_type<ast::function_type>(std::move(return_type), std::move(arg_types));
     func_decl->params = std::move(args);
     return func_decl;
 }

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -452,7 +452,7 @@ ast::type_ptr parser::parse_type() {
     // a type can either be some primitive or a user-defined type.
     switch (lex->peek_token().type) {
     case lexer::token_type::identifier: {
-        auto type_ptr = ast::user_type::lookup(lex->next_token().text, module_name());
+        auto type_ptr = ty_context.lookup_user_type(lex->next_token().text, module_name());
         assert(type_ptr != nullptr);
         return type_ptr;
     }

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -14,18 +14,19 @@
 #include <string_utils.hpp> // unquote
 
 std::unique_ptr<parser> parser::from_file(const std::string & filename,
-                                          const std::filesystem::path & project_root) {
+                                          const std::filesystem::path & project_root,
+                                          ast::type_context & ty_context) {
     auto lexer = lexer::from_file(filename);
     if (lexer == nullptr) { return nullptr; }
     // NOTE: `make_unique` does not like private constructors.
-    return std::unique_ptr<parser>(new parser{std::move(lexer), project_root});
+    return std::unique_ptr<parser>(new parser{std::move(lexer), ty_context, project_root});
 }
 
-std::unique_ptr<parser> parser::from_buffer(std::string & buffer) {
+std::unique_ptr<parser> parser::from_buffer(std::string & buffer, ast::type_context & ty_context) {
     auto lexer = lexer::from_buffer(buffer);
     if (lexer == nullptr) { return nullptr; }
     // NOTE: `make_unique` does not like private constructors.
-    return std::unique_ptr<parser>(new parser{std::move(lexer)});
+    return std::unique_ptr<parser>(new parser{std::move(lexer), ty_context});
 }
 
 std::unique_ptr<ast::top_level_sequence> parser::parse() {

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -187,7 +187,7 @@ std::unique_ptr<ast::func_decl> parser::parse_function() {
     tok = lex->next_token();
     assert(tok == lexer::token_type::rparen);
 
-    auto return_type = ast::prim_type::unit;
+    auto return_type = ty_context.create_type<ast::prim_type>(ast::prim_type::type::unit);
     // Parse the optional return type.
     if (lex->consume_if(lexer::token_type::arrow).has_value()) { return_type = parse_type(); }
 
@@ -462,9 +462,12 @@ ast::type_ptr parser::parse_type() {
     }
     case lexer::token_type::prim_type: {
         static const std::map<std::string, ast::type_ptr> prim_types{
-            {"int", ast::prim_type::int32},      {"float", ast::prim_type::float32},
-            {"char", ast::prim_type::character}, {"unit", ast::prim_type::unit},
-            {"bool", ast::prim_type::boolean},   {"string", ast::prim_type::str},
+            {"int", ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32)},
+            {"float", ty_context.create_type<ast::prim_type>(ast::prim_type::type::float32)},
+            {"char", ty_context.create_type<ast::prim_type>(ast::prim_type::type::character)},
+            {"unit", ty_context.create_type<ast::prim_type>(ast::prim_type::type::unit)},
+            {"bool", ty_context.create_type<ast::prim_type>(ast::prim_type::type::boolean)},
+            {"string", ty_context.create_type<ast::prim_type>(ast::prim_type::type::str)},
         };
         auto iter = prim_types.find(lex->next_token().text);
         assert(iter != prim_types.end());

--- a/src/ast/parser.hpp
+++ b/src/ast/parser.hpp
@@ -7,6 +7,7 @@
 #include "node_utils.hpp"
 #include "nodes_forward.hpp"
 #include "type.hpp"
+#include "type_context.hpp"
 
 #include <filesystem>
 #include <map>
@@ -30,13 +31,15 @@ class parser final {
     // `from_file` loads a file from given filename and uses that as input.
     // The file data is internally allocated and freed by the parser.
     static std::unique_ptr<parser> from_file(const std::string & filename,
-                                             const std::filesystem::path & project_root);
+                                             const std::filesystem::path & project_root,
+                                             ast::type_context & ty_context);
 
     // `from_buffer` uses the given string as its input.
     // Note that the parser does not own the string and maintains a readonly view into it.
     // The caller must store the string *and* ensure that it is not modified while the parser is
     // alive.
-    static std::unique_ptr<parser> from_buffer(std::string & buffer);
+    static std::unique_ptr<parser> from_buffer(std::string & buffer,
+                                               ast::type_context & ty_context);
 
     // `parse` parses a single module (one file).
     // Any failure in parsing results in a `nullptr`.
@@ -53,10 +56,11 @@ class parser final {
     ~parser() noexcept = default;
 
   private:
-    explicit parser(lex_ptr && lex,
+    explicit parser(lex_ptr && lex, ast::type_context & ty_context,
                     std::optional<std::filesystem::path> project_root = std::nullopt)
         : project_root{std::move(project_root)}
-        , lex{std::move(lex)} {}
+        , lex{std::move(lex)}
+        , ty_context{ty_context} {}
 
     // As stated above,
     // there are some internals which need to be tested independently of each other.
@@ -120,6 +124,7 @@ class parser final {
     }
 
     lex_ptr lex;
+    ast::type_context & ty_context;
     std::string error;
 };
 

--- a/src/ast/serializer.cpp
+++ b/src/ast/serializer.cpp
@@ -65,8 +65,8 @@ namespace ast {
 
         for (auto & param : func_decl.params) { params.push_back(get_value(param, *this)); }
 
-        assert(func_decl.ret_type != nullptr);
-        auto return_type = (std::stringstream{} << *func_decl.ret_type).str();
+        assert(func_decl.func_type != nullptr);
+        auto return_type = (std::stringstream{} << *func_decl.func_type->return_type()).str();
 
         return store_result(nlohmann::json::object_t{{"body", std::move(body)},
                                                      {"name", func_decl.name},

--- a/src/ast/top_lvl_nodes.hpp
+++ b/src/ast/top_lvl_nodes.hpp
@@ -102,8 +102,7 @@ namespace ast {
 
         std::string name;
         std::vector<typed_identifier> fields;
-
-        [[nodiscard]] std::shared_ptr<ast::struct_type> type(const std::string & module_name) const;
+        std::shared_ptr<ast::struct_type> type;
 
       private:
         void update_export(bool /*val*/) final {}

--- a/src/ast/top_lvl_nodes.hpp
+++ b/src/ast/top_lvl_nodes.hpp
@@ -41,8 +41,9 @@ namespace ast {
 
     class func_decl final : public top_level {
       public:
-        func_decl(std::string name, stmt_ptr body)
+        func_decl(std::string name, ast::function_type * func_type, stmt_ptr body)
             : name{std::move(name)}
+            , func_type{func_type}
             , body(std::move(body)) {}
 
         non_copyable(func_decl);
@@ -57,7 +58,7 @@ namespace ast {
 
         std::string name;
         std::vector<typed_identifier> params;
-        std::shared_ptr<ast::function_type> func_type;
+        ast::function_type * func_type;
         stmt_ptr body;
 
       private:
@@ -87,9 +88,11 @@ namespace ast {
 
     class struct_decl final : public top_level {
       public:
-        explicit struct_decl(std::string name, std::vector<typed_identifier> && fields = {})
+        explicit struct_decl(std::string name, ast::struct_type * type,
+                             std::vector<typed_identifier> && fields = {})
             : name(std::move(name))
-            , fields{std::move(fields)} {}
+            , fields{std::move(fields)}
+            , type{type} {}
 
         non_copyable(struct_decl);
 
@@ -101,7 +104,7 @@ namespace ast {
 
         std::string name;
         std::vector<typed_identifier> fields;
-        std::shared_ptr<ast::struct_type> type;
+        ast::struct_type * type;
 
       private:
         void update_export(bool /*val*/) final {}

--- a/src/ast/top_lvl_nodes.hpp
+++ b/src/ast/top_lvl_nodes.hpp
@@ -52,13 +52,12 @@ namespace ast {
         ~func_decl() noexcept final = default;
 
         [[nodiscard]] size_t param_count() const { return params.size(); }
-        [[nodiscard]] std::shared_ptr<ast::function_type> func_type() const;
 
         make_visitable;
 
         std::string name;
         std::vector<typed_identifier> params;
-        ast::type_ptr ret_type;
+        std::shared_ptr<ast::function_type> func_type;
         stmt_ptr body;
 
       private:

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -17,38 +17,13 @@ namespace ast {
     const type_ptr prim_type::null = type_ptr{new prim_type{ast::prim_type::type::null}};
 
     std::shared_ptr<nullable_ptr_type> nullable_ptr_type::create(type_ptr pointed_to_type) {
-        static std::map<type_ptr, std::shared_ptr<nullable_ptr_type>> made_types;
-
-        if (auto iter = made_types.find(pointed_to_type); iter != made_types.end()) {
-            return iter->second;
-        }
-
-        auto new_ptr_type
-            = std::shared_ptr<nullable_ptr_type>{new nullable_ptr_type{pointed_to_type}};
-        made_types.emplace(std::move(pointed_to_type), new_ptr_type);
-
-        return new_ptr_type;
+        return std::shared_ptr<nullable_ptr_type>{
+            new nullable_ptr_type{std::move(pointed_to_type)}};
     }
 
     std::shared_ptr<nonnullable_ptr_type> nonnullable_ptr_type::create(type_ptr pointed_to_type) {
-        static std::map<type_ptr, std::shared_ptr<nonnullable_ptr_type>> made_types;
-
-        if (auto iter = made_types.find(pointed_to_type); iter != made_types.end()) {
-            return iter->second;
-        }
-
-        auto new_ptr_type
-            = std::shared_ptr<nonnullable_ptr_type>{new nonnullable_ptr_type{pointed_to_type}};
-        made_types.emplace(std::move(pointed_to_type), new_ptr_type);
-
-        return new_ptr_type;
-    }
-
-    std::shared_ptr<user_type> user_type::lookup(const std::string & name,
-                                                 const std::string & module_name) {
-        assert(not name.empty());
-
-        return user_made_types.lookup(module_name, name);
+        return std::shared_ptr<nonnullable_ptr_type>{
+            new nonnullable_ptr_type{std::move(pointed_to_type)}};
     }
 
     std::shared_ptr<struct_type> struct_type::create(std::string && name,

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -8,14 +8,6 @@
 namespace ast {
     // Type creation
 
-    const type_ptr prim_type::int32 = type_ptr{new prim_type{ast::prim_type::type::int32}};
-    const type_ptr prim_type::unit = type_ptr{new prim_type{ast::prim_type::type::unit}};
-    const type_ptr prim_type::float32 = type_ptr{new prim_type{ast::prim_type::type::float32}};
-    const type_ptr prim_type::boolean = type_ptr{new prim_type{ast::prim_type::type::boolean}};
-    const type_ptr prim_type::str = type_ptr{new prim_type{ast::prim_type::type::str}};
-    const type_ptr prim_type::character = type_ptr{new prim_type{ast::prim_type::type::character}};
-    const type_ptr prim_type::null = type_ptr{new prim_type{ast::prim_type::type::null}};
-
     std::shared_ptr<nullable_ptr_type> nullable_ptr_type::create(type_ptr pointed_to_type) {
         return std::shared_ptr<nullable_ptr_type>{
             new nullable_ptr_type{std::move(pointed_to_type)}};

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -34,22 +34,8 @@ namespace ast {
         // TODO: The "" module may be useful.
         assert(not module_name.empty());
 
-        if (auto old_type = user_type::lookup(name, module_name); old_type != nullptr) {
-            if (auto possible_struct = std::dynamic_pointer_cast<struct_type>(old_type);
-                possible_struct != nullptr) {
-                return possible_struct;
-            }
-
-            std::cout << "Type " << name << " is already registered in " << module_name
-                      << " as a non-struct type" << std::endl;
-            assert(false);
-        }
-
-        auto new_user_type = std::shared_ptr<struct_type>{
-            new struct_type{std::string{name}, module_name, std::move(fields)}};
-        add_user_type(module_name, name, new_user_type);
-
-        return new_user_type;
+        return std::shared_ptr<struct_type>{
+            new struct_type{std::move(name), module_name, std::move(fields)}};
     }
 
     std::shared_ptr<function_type> function_type::create(ast::type_ptr ret_type,

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -1,9 +1,9 @@
 #include "type.hpp"
 
 #include <algorithm> // find_if
-#include <iostream>  // cout
-
-#include <global_map.hpp>
+#include <cassert>
+#include <iostream> // cout
+#include <utility>
 
 namespace ast {
     // Type creation
@@ -40,22 +40,8 @@ namespace ast {
 
     std::shared_ptr<function_type> function_type::create(ast::type_ptr ret_type,
                                                          std::vector<ast::type_ptr> && arg_types) {
-        static std::vector<std::shared_ptr<function_type>> made_types;
-
-        if (auto iter = std::find_if(made_types.begin(), made_types.end(),
-                                     [&ret_type, &arg_types](const auto & exisiting_type) -> bool {
-                                         return exisiting_type->ret_type == ret_type
-                                            and exisiting_type->arg_types == arg_types;
-                                     });
-            iter != made_types.end()) {
-            return *iter;
-        }
-
-        auto new_func_type = std::shared_ptr<function_type>{
+        return std::shared_ptr<function_type>{
             new function_type{std::move(ret_type), std::move(arg_types)}};
-        made_types.push_back(new_func_type);
-
-        return new_func_type;
     }
 
     // Printing types

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -16,6 +16,10 @@ namespace ast {
         return std::unique_ptr<nonnullable_ptr_type>{new nonnullable_ptr_type{pointed_to_type}};
     }
 
+    std::unique_ptr<prim_type> prim_type::create(prim_type::type type) {
+        return std::unique_ptr<prim_type>{new prim_type{type}};
+    }
+
     std::unique_ptr<struct_type> struct_type::create(std::string && name,
                                                      const std::string & module_name,
                                                      std::vector<field_type> && fields) {

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -70,8 +70,8 @@ namespace ast {
             assert(false);
         }
 
-        auto new_user_type
-            = std::shared_ptr<struct_type>{new struct_type{std::string{name}, std::move(fields)}};
+        auto new_user_type = std::shared_ptr<struct_type>{
+            new struct_type{std::string{name}, module_name, std::move(fields)}};
         add_user_type(module_name, name, new_user_type);
 
         return new_user_type;

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -8,17 +8,15 @@
 namespace ast {
     // Type creation
 
-    std::shared_ptr<nullable_ptr_type> nullable_ptr_type::create(type_ptr pointed_to_type) {
-        return std::shared_ptr<nullable_ptr_type>{
-            new nullable_ptr_type{std::move(pointed_to_type)}};
+    std::unique_ptr<nullable_ptr_type> nullable_ptr_type::create(type_ptr pointed_to_type) {
+        return std::unique_ptr<nullable_ptr_type>{new nullable_ptr_type{pointed_to_type}};
     }
 
-    std::shared_ptr<nonnullable_ptr_type> nonnullable_ptr_type::create(type_ptr pointed_to_type) {
-        return std::shared_ptr<nonnullable_ptr_type>{
-            new nonnullable_ptr_type{std::move(pointed_to_type)}};
+    std::unique_ptr<nonnullable_ptr_type> nonnullable_ptr_type::create(type_ptr pointed_to_type) {
+        return std::unique_ptr<nonnullable_ptr_type>{new nonnullable_ptr_type{pointed_to_type}};
     }
 
-    std::shared_ptr<struct_type> struct_type::create(std::string && name,
+    std::unique_ptr<struct_type> struct_type::create(std::string && name,
                                                      const std::string & module_name,
                                                      std::vector<field_type> && fields) {
 
@@ -26,14 +24,13 @@ namespace ast {
         // TODO: The "" module may be useful.
         assert(not module_name.empty());
 
-        return std::shared_ptr<struct_type>{
+        return std::unique_ptr<struct_type>{
             new struct_type{std::move(name), module_name, std::move(fields)}};
     }
 
-    std::shared_ptr<function_type> function_type::create(ast::type_ptr ret_type,
+    std::unique_ptr<function_type> function_type::create(ast::type_ptr ret_type,
                                                          std::vector<ast::type_ptr> && arg_types) {
-        return std::shared_ptr<function_type>{
-            new function_type{std::move(ret_type), std::move(arg_types)}};
+        return std::unique_ptr<function_type>{new function_type{ret_type, std::move(arg_types)}};
     }
 
     // Printing types

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <global_map.hpp>
 #include <move_copy.hpp>
 
 namespace ast {
@@ -126,9 +125,6 @@ namespace ast {
 
     struct user_type : public type {
 
-        static std::shared_ptr<user_type> lookup(const std::string & type_name,
-                                                 const std::string & module_name);
-
         non_copyable(user_type);
         non_movable(user_type);
         ~user_type() override = default;
@@ -143,14 +139,7 @@ namespace ast {
             : name{std::move(name)}
             , module_name{std::move(module_name)} {}
 
-        static void add_user_type(const std::string & module_name, const std::string & name,
-                                  std::shared_ptr<user_type> type) {
-            user_made_types.add(module_name, name, std::move(type));
-        }
-
       private:
-        // NOLINTNEXTLINE
-        inline static global_map<std::string, std::shared_ptr<user_type>> user_made_types;
         std::string name;
         std::string module_name;
     };
@@ -158,10 +147,6 @@ namespace ast {
     struct struct_type final : public user_type {
 
         using field_type = std::pair<std::string, ast::type_ptr>;
-
-        static std::shared_ptr<struct_type> create(std::string && name,
-                                                   const std::string & module_name,
-                                                   std::vector<field_type> && fields);
 
         non_copyable(struct_type);
         non_movable(struct_type);
@@ -172,6 +157,10 @@ namespace ast {
         [[nodiscard]] const field_type & field(size_t index) const { return fields[index]; }
 
       private:
+        static std::shared_ptr<struct_type> create(std::string && name,
+                                                   const std::string & module_name,
+                                                   std::vector<field_type> && fields);
+
         struct_type(std::string && name, std::string module_name, std::vector<field_type> && fields)
             : user_type{std::move(name), std::move(module_name)}
             , fields{std::move(fields)} {}
@@ -179,6 +168,8 @@ namespace ast {
         std::vector<field_type> fields;
 
         void print(std::ostream & /*output*/) const override;
+
+        friend class type_context;
     };
 
     struct function_type final : public type {

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -101,6 +101,8 @@ namespace ast {
             return prim == type::str or prim == type::null;
         }
 
+        [[nodiscard]] type inner() const noexcept { return prim; }
+
         static const type_ptr int32;
         static const type_ptr unit;
         static const type_ptr float32;

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -173,9 +173,6 @@ namespace ast {
     };
 
     struct function_type final : public type {
-        static std::shared_ptr<function_type> create(ast::type_ptr ret_type,
-                                                     std::vector<ast::type_ptr> && arg_types = {});
-
         non_copyable(function_type);
         non_movable(function_type);
         ~function_type() final = default;
@@ -187,6 +184,9 @@ namespace ast {
         [[nodiscard]] type_ptr return_type() const { return ret_type; }
 
       private:
+        static std::shared_ptr<function_type> create(ast::type_ptr ret_type,
+                                                     std::vector<ast::type_ptr> && arg_types = {});
+
         explicit function_type(ast::type_ptr ret_type, std::vector<ast::type_ptr> && arg_types = {})
             : ret_type{std::move(ret_type)}
             , arg_types{std::move(arg_types)} {}
@@ -195,6 +195,8 @@ namespace ast {
         std::vector<ast::type_ptr> arg_types;
 
         void print(std::ostream & /*output*/) const final;
+
+        friend class type_context;
     };
 
 } // namespace ast

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -106,14 +106,6 @@ namespace ast {
 
         [[nodiscard]] type inner() const noexcept { return prim; }
 
-        static const type_ptr int32;
-        static const type_ptr unit;
-        static const type_ptr float32;
-        static const type_ptr boolean;
-        static const type_ptr str;
-        static const type_ptr character;
-        static const type_ptr null;
-
       private:
         explicit prim_type(type prim)
             : prim{prim} {}
@@ -121,6 +113,8 @@ namespace ast {
         void print(std::ostream & /*output*/) const final;
 
         type prim;
+
+        // TODO: This class has no need to be friends with type_context
     };
 
     struct user_type : public type {

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -131,11 +131,13 @@ namespace ast {
 
         [[nodiscard]] bool is_pointer_type() const final { return false; }
 
+        [[nodiscard]] const std::string & containing_module_name() const { return module_name; }
         [[nodiscard]] const std::string & user_name() const { return name; }
 
       protected:
-        explicit user_type(std::string name)
-            : name{std::move(name)} {}
+        explicit user_type(std::string name, std::string module_name)
+            : name{std::move(name)}
+            , module_name{std::move(module_name)} {}
 
         static void add_user_type(const std::string & module_name, const std::string & name,
                                   std::shared_ptr<user_type> type) {
@@ -146,6 +148,7 @@ namespace ast {
         // NOLINTNEXTLINE
         inline static global_map<std::string, std::shared_ptr<user_type>> user_made_types;
         std::string name;
+        std::string module_name;
     };
 
     struct struct_type final : public user_type {
@@ -165,8 +168,8 @@ namespace ast {
         [[nodiscard]] const field_type & field(size_t index) const { return fields[index]; }
 
       private:
-        struct_type(std::string && name, std::vector<field_type> && fields)
-            : user_type{std::move(name)}
+        struct_type(std::string && name, std::string module_name, std::vector<field_type> && fields)
+            : user_type{std::move(name), std::move(module_name)}
             , fields{std::move(fields)} {}
 
         std::vector<field_type> fields;

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -2,7 +2,7 @@
 #define TYPE_HPP
 
 #include <iosfwd> // ostream
-#include <memory> // shared_ptr
+#include <memory> // unique_ptr
 #include <string>
 #include <vector>
 
@@ -29,7 +29,7 @@ namespace ast {
         virtual void print(std::ostream &) const = 0;
     };
 
-    using type_ptr = std::shared_ptr<type>;
+    using type_ptr = type *;
 
     class ptr_type : public type {
       public:
@@ -40,7 +40,7 @@ namespace ast {
 
       protected:
         ptr_type(type_ptr inner)
-            : pointed_to{std::move(inner)} {}
+            : pointed_to{inner} {}
 
       private:
         type_ptr pointed_to;
@@ -55,10 +55,10 @@ namespace ast {
         [[nodiscard]] bool nullable() const noexcept final { return true; }
 
       private:
-        static std::shared_ptr<nullable_ptr_type> create(type_ptr pointed_to_type);
+        static std::unique_ptr<nullable_ptr_type> create(type_ptr pointed_to_type);
 
         explicit nullable_ptr_type(type_ptr inner)
-            : ptr_type{std::move(inner)} {}
+            : ptr_type{inner} {}
 
         void print(std::ostream & /*output*/) const final;
 
@@ -74,10 +74,10 @@ namespace ast {
         [[nodiscard]] bool nullable() const noexcept final { return false; }
 
       private:
-        static std::shared_ptr<nonnullable_ptr_type> create(type_ptr pointed_to_type);
+        static std::unique_ptr<nonnullable_ptr_type> create(type_ptr pointed_to_type);
 
         explicit nonnullable_ptr_type(type_ptr inner)
-            : ptr_type{std::move(inner)} {}
+            : ptr_type{inner} {}
 
         void print(std::ostream & /*output*/) const final;
 
@@ -151,7 +151,7 @@ namespace ast {
         [[nodiscard]] const field_type & field(size_t index) const { return fields[index]; }
 
       private:
-        static std::shared_ptr<struct_type> create(std::string && name,
+        static std::unique_ptr<struct_type> create(std::string && name,
                                                    const std::string & module_name,
                                                    std::vector<field_type> && fields);
 
@@ -178,11 +178,11 @@ namespace ast {
         [[nodiscard]] type_ptr return_type() const { return ret_type; }
 
       private:
-        static std::shared_ptr<function_type> create(ast::type_ptr ret_type,
+        static std::unique_ptr<function_type> create(ast::type_ptr ret_type,
                                                      std::vector<ast::type_ptr> && arg_types = {});
 
         explicit function_type(ast::type_ptr ret_type, std::vector<ast::type_ptr> && arg_types = {})
-            : ret_type{std::move(ret_type)}
+            : ret_type{ret_type}
             , arg_types{std::move(arg_types)} {}
 
         ast::type_ptr ret_type;

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -107,6 +107,8 @@ namespace ast {
         [[nodiscard]] type inner() const noexcept { return prim; }
 
       private:
+        static std::unique_ptr<prim_type> create(type type);
+
         explicit prim_type(type prim)
             : prim{prim} {}
 
@@ -114,7 +116,7 @@ namespace ast {
 
         type prim;
 
-        // TODO: This class has no need to be friends with type_context
+        friend class type_context;
     };
 
     struct user_type : public type {

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -49,8 +49,6 @@ namespace ast {
 
     struct nullable_ptr_type final : public ptr_type {
 
-        static std::shared_ptr<nullable_ptr_type> create(type_ptr pointed_to_type);
-
         non_copyable(nullable_ptr_type);
         non_movable(nullable_ptr_type);
         ~nullable_ptr_type() final = default;
@@ -58,15 +56,17 @@ namespace ast {
         [[nodiscard]] bool nullable() const noexcept final { return true; }
 
       private:
+        static std::shared_ptr<nullable_ptr_type> create(type_ptr pointed_to_type);
+
         explicit nullable_ptr_type(type_ptr inner)
             : ptr_type{std::move(inner)} {}
 
         void print(std::ostream & /*output*/) const final;
+
+        friend class type_context;
     };
 
     struct nonnullable_ptr_type final : public ptr_type {
-
-        static std::shared_ptr<nonnullable_ptr_type> create(type_ptr pointed_to_type);
 
         non_copyable(nonnullable_ptr_type);
         non_movable(nonnullable_ptr_type);
@@ -75,10 +75,14 @@ namespace ast {
         [[nodiscard]] bool nullable() const noexcept final { return false; }
 
       private:
+        static std::shared_ptr<nonnullable_ptr_type> create(type_ptr pointed_to_type);
+
         explicit nonnullable_ptr_type(type_ptr inner)
             : ptr_type{std::move(inner)} {}
 
         void print(std::ostream & /*output*/) const final;
+
+        friend class type_context;
     };
 
     struct prim_type final : public type {

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -2,6 +2,8 @@
 
 #include "type.hpp"
 
+#include <cassert>
+
 namespace ast {
     type_context::type_context() {
         (void)create_type<ast::prim_type>(ast::prim_type::type::boolean);
@@ -80,4 +82,16 @@ namespace ast {
         return struct_type::create(std::move(name), module_name, std::move(fields));
     }
 
+    type_ptr type_context::lookup_user_type(const std::string & name,
+                                            const std::string & module_name) {
+        for (auto & type_ptr : types) {
+            if (auto ptr = std::dynamic_pointer_cast<ast::user_type>(type_ptr); ptr != nullptr) {
+                if (ptr->containing_module_name() == module_name and ptr->user_name() == name) {
+                    return ptr;
+                }
+            }
+        }
+
+        return nullptr;
+    }
 } // namespace ast

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -62,8 +62,9 @@ namespace ast {
         return function_type::create(std::move(return_type), std::move(arg_types));
     }
 
-    type_ptr type_context::find_struct_type(std::string && name, const std::string & module_name,
-                                            std::vector<struct_type::field_type> && fields) {
+    std::shared_ptr<ast::struct_type>
+    type_context::find_struct_type(std::string && name, const std::string & module_name,
+                                   std::vector<struct_type::field_type> && fields) {
 
         for (auto & type_ptr : types) {
             if (auto ptr = std::dynamic_pointer_cast<ast::struct_type>(type_ptr); ptr != nullptr) {

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -42,8 +42,8 @@ namespace ast {
                            : nonnullable_ptr_type::create(std::move(pointed_to));
     }
 
-    type_ptr type_context::find_function_type(type_ptr return_type,
-                                              std::vector<type_ptr> && arg_types) {
+    std::shared_ptr<function_type>
+    type_context::find_function_type(type_ptr return_type, std::vector<type_ptr> && arg_types) {
 
         for (auto & type_ptr : types) {
             if (auto ptr = std::dynamic_pointer_cast<ast::function_type>(type_ptr);

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -24,8 +24,8 @@ namespace ast {
             }
         }
 
-        // TODO: We may want to lazily allocate prim_types
-        assert(false);
+        types.emplace_back(ast::prim_type::create(type));
+        return types.back().get();
     }
 
     type_ptr type_context::find_ptr_type(bool is_nullable, type_ptr pointed_to) {

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -1,0 +1,83 @@
+#include "type_context.hpp"
+
+#include "type.hpp"
+
+namespace ast {
+    type_context::type_context() {
+        (void)create_type<ast::prim_type>(ast::prim_type::type::boolean);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::character);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::float32);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::int32);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::null);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::str);
+        (void)create_type<ast::prim_type>(ast::prim_type::type::unit);
+    }
+
+    type_ptr type_context::find_prim_type(ast::prim_type::type type) {
+        // We should always find a prim_type
+
+        for (auto & type_ptr : types) {
+            if (auto ptr = std::dynamic_pointer_cast<ast::prim_type>(type_ptr); ptr != nullptr) {
+                if (ptr->inner() == type) { return ptr; }
+            }
+        }
+
+        // TODO: We may want to lazily allocate prim_types
+        assert(false);
+    }
+
+    type_ptr type_context::find_ptr_type(bool is_nullable, type_ptr pointed_to) {
+        for (auto & type_ptr : types) {
+            if (auto ptr = std::dynamic_pointer_cast<ast::ptr_type>(type_ptr); ptr != nullptr) {
+                if (ptr->nullable() == is_nullable and ptr->pointed_to_type() == pointed_to) {
+                    return ptr;
+                }
+            }
+        }
+
+        return is_nullable ? static_cast<std::shared_ptr<ast::ptr_type>>(
+                   nullable_ptr_type::create(std::move(pointed_to)))
+                           : nonnullable_ptr_type::create(std::move(pointed_to));
+    }
+
+    type_ptr type_context::find_function_type(type_ptr return_type,
+                                              std::vector<type_ptr> && arg_types) {
+
+        for (auto & type_ptr : types) {
+            if (auto ptr = std::dynamic_pointer_cast<ast::function_type>(type_ptr);
+                ptr != nullptr) {
+                if (ptr->return_type() != return_type) { continue; }
+                if (ptr->arg_count() != arg_types.size()) { continue; }
+
+                for (auto i = 0UL; i < ptr->arg_count(); ++i) {
+                    if (ptr->arg(i) != arg_types[i]) { continue; }
+                }
+
+                return ptr;
+            }
+        }
+
+        return function_type::create(std::move(return_type), std::move(arg_types));
+    }
+
+    type_ptr type_context::find_struct_type(std::string && name, const std::string & module_name,
+                                            std::vector<struct_type::field_type> && fields) {
+
+        for (auto & type_ptr : types) {
+            if (auto ptr = std::dynamic_pointer_cast<ast::struct_type>(type_ptr); ptr != nullptr) {
+                if (ptr->containing_module_name() != module_name) { continue; }
+                if (ptr->user_name() != name) { continue; }
+                if (ptr->field_count() != fields.size()) { continue; }
+
+                for (auto i = 0UL; i < ptr->field_count(); ++i) {
+                    if (ptr->field(i) != fields[i]) { continue; }
+                }
+
+                return ptr;
+            }
+        }
+
+        return struct_type::create(std::move(name), module_name, std::move(fields));
+    }
+
+} // namespace ast

--- a/src/ast/type_context.cpp
+++ b/src/ast/type_context.cpp
@@ -5,15 +5,6 @@
 #include <cassert>
 
 namespace ast {
-    type_context::type_context() {
-        (void)create_type<ast::prim_type>(ast::prim_type::type::boolean);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::character);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::float32);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::int32);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::null);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::str);
-        (void)create_type<ast::prim_type>(ast::prim_type::type::unit);
-    }
 
     type_ptr type_context::find_prim_type(ast::prim_type::type type) {
         // We should always find a prim_type

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -14,7 +14,7 @@ namespace ast {
         ~type_context() noexcept = default;
 
         template<typename type_t, typename... arg_t>
-        [[nodiscard]] type_ptr create_type(arg_t... args) {
+        [[nodiscard]] auto create_type(arg_t... args) {
             // Delagate to functions that will enforce each types uniqueness rules.
             if constexpr (std::is_same_v<type_t, ast::prim_type>) {
                 // All primitive types should have been made by the constructor.
@@ -46,9 +46,9 @@ namespace ast {
         [[nodiscard]] type_ptr find_ptr_type(bool is_nullable, type_ptr pointed_to);
         [[nodiscard]] type_ptr find_function_type(type_ptr return_type,
                                                   std::vector<type_ptr> && arg_types = {});
-        [[nodiscard]] type_ptr find_struct_type(std::string && name,
-                                                const std::string & module_name,
-                                                std::vector<struct_type::field_type> && fields);
+        [[nodiscard]] std::shared_ptr<ast::struct_type>
+        find_struct_type(std::string && name, const std::string & module_name,
+                         std::vector<struct_type::field_type> && fields);
 
         std::vector<type_ptr> types;
     };

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -14,7 +14,7 @@ namespace ast {
         ~type_context() noexcept = default;
 
         template<typename type_t, typename... arg_t>
-        [[nodiscard]] auto create_type(arg_t... args) {
+        [[nodiscard]] auto * create_type(arg_t... args) {
             // Delagate to functions that will enforce each types uniqueness rules.
             if constexpr (std::is_same_v<type_t, ast::prim_type>) {
                 // All primitive types should have been made by the constructor.
@@ -43,14 +43,14 @@ namespace ast {
       private:
         [[nodiscard]] type_ptr find_prim_type(prim_type::type type);
         [[nodiscard]] type_ptr find_ptr_type(bool is_nullable, type_ptr pointed_to);
-        [[nodiscard]] std::shared_ptr<ast::function_type>
+        [[nodiscard]] ast::function_type *
         find_function_type(type_ptr return_type, std::vector<type_ptr> && arg_types = {});
 
-        [[nodiscard]] std::shared_ptr<ast::struct_type>
+        [[nodiscard]] ast::struct_type *
         find_struct_type(std::string && name, const std::string & module_name,
                          std::vector<struct_type::field_type> && fields);
 
-        std::vector<type_ptr> types;
+        std::vector<std::unique_ptr<ast::type>> types;
     };
 } // namespace ast
 

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -6,7 +6,7 @@
 namespace ast {
     class type_context final {
       public:
-        type_context();
+        type_context() = default;
 
         non_copyable(type_context);
         non_movable(type_context);

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -51,6 +51,9 @@ namespace ast {
         find_struct_type(std::string && name, const std::string & module_name,
                          std::vector<struct_type::field_type> && fields);
 
+        template<typename type_t, typename... args_t>
+        [[nodiscard]] type_t * emplace_type(args_t... args);
+
         std::vector<std::unique_ptr<ast::type>> types;
     };
 } // namespace ast

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -15,16 +15,17 @@ namespace ast {
 
         template<typename type_t, typename... arg_t>
         [[nodiscard]] auto * create_type(arg_t... args) {
+            static_assert(std::is_class_v<type_t>);
+            static_assert(std::is_convertible_v<type_t *, type *>);
             // Delagate to functions that will enforce each types uniqueness rules.
             if constexpr (std::is_same_v<type_t, ast::prim_type>) {
                 // All primitive types should have been made by the constructor.
                 static_assert(sizeof...(args) == 1);
                 return find_prim_type(args...);
-                // TODO: Fix formatting
-            } else if constexpr (
-                std::is_same_v<
-                    type_t,
-                    ast::nonnullable_ptr_type> or std::is_same_v<type_t, ast::nullable_ptr_type>) {
+            } else if constexpr (std::is_convertible_v<type_t *, ptr_type *>) {
+                // NOTE: The preceding check is broader than necessary,
+                // as `ptr_type` could have more children in the future.
+                // This could lead to some issues at that time.
                 static_assert(sizeof...(args) == 1);
                 return find_ptr_type(std::is_same_v<type_t, ast::nullable_ptr_type>, args...);
             } else if constexpr (std::is_same_v<type_t, ast::function_type>) {

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -34,7 +34,7 @@ namespace ast {
                 return find_function_type(args...);
             } else if constexpr (std::is_same_v<type_t, ast::struct_type>) {
                 static_assert(sizeof...(args) == 3);
-                return find_struct(args...);
+                return find_struct_type(std::forward<arg_t>(args)...);
             }
         }
 

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -1,0 +1,54 @@
+#ifndef AST_TYPE_CONTEXT_HPP
+#define AST_TYPE_CONTEXT_HPP
+
+#include "type.hpp"
+
+namespace ast {
+    class type_context final {
+      public:
+        type_context();
+
+        non_copyable(type_context);
+        non_movable(type_context);
+
+        ~type_context() noexcept = default;
+
+        template<typename type_t, typename... arg_t>
+        [[nodiscard]] type_ptr create_type(arg_t... args) {
+            // Delagate to functions that will enforce each types uniqueness rules.
+            if constexpr (std::is_same_v<type_t, ast::prim_type>) {
+                // All primitive types should have been made by the constructor.
+                static_assert(sizeof...(args) == 1);
+                return find_prim_type(args...);
+                // TODO: Fix formatting
+            } else if constexpr (
+                std::is_same_v<
+                    type_t,
+                    ast::nonnullable_ptr_type> or std::is_same_v<type_t, ast::nullable_ptr_type>) {
+                static_assert(sizeof...(args) == 1);
+                return find_ptr_type(std::is_same_v<type_t, ast::nullable_ptr_type>, args...);
+            } else if constexpr (std::is_same_v<type_t, ast::function_type>) {
+                static_assert(sizeof...(args) > 0);
+                static_assert(sizeof...(args) <= 2);
+                // TODO: use std::forward
+                return find_function_type(args...);
+            } else if constexpr (std::is_same_v<type_t, ast::struct_type>) {
+                static_assert(sizeof...(args) == 3);
+                return find_struct(args...);
+            }
+        }
+
+      private:
+        [[nodiscard]] type_ptr find_prim_type(prim_type::type type);
+        [[nodiscard]] type_ptr find_ptr_type(bool is_nullable, type_ptr pointed_to);
+        [[nodiscard]] type_ptr find_function_type(type_ptr return_type,
+                                                  std::vector<type_ptr> && arg_types = {});
+        [[nodiscard]] type_ptr find_struct_type(std::string && name,
+                                                const std::string & module_name,
+                                                std::vector<struct_type::field_type> && fields);
+
+        std::vector<type_ptr> types;
+    };
+} // namespace ast
+
+#endif

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -38,6 +38,9 @@ namespace ast {
             }
         }
 
+        [[nodiscard]] type_ptr lookup_user_type(const std::string & name,
+                                                const std::string & module_name);
+
       private:
         [[nodiscard]] type_ptr find_prim_type(prim_type::type type);
         [[nodiscard]] type_ptr find_ptr_type(bool is_nullable, type_ptr pointed_to);

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -30,8 +30,7 @@ namespace ast {
             } else if constexpr (std::is_same_v<type_t, ast::function_type>) {
                 static_assert(sizeof...(args) > 0);
                 static_assert(sizeof...(args) <= 2);
-                // TODO: use std::forward
-                return find_function_type(args...);
+                return find_function_type(std::forward<arg_t>(args)...);
             } else if constexpr (std::is_same_v<type_t, ast::struct_type>) {
                 static_assert(sizeof...(args) == 3);
                 return find_struct_type(std::forward<arg_t>(args)...);
@@ -44,8 +43,9 @@ namespace ast {
       private:
         [[nodiscard]] type_ptr find_prim_type(prim_type::type type);
         [[nodiscard]] type_ptr find_ptr_type(bool is_nullable, type_ptr pointed_to);
-        [[nodiscard]] type_ptr find_function_type(type_ptr return_type,
-                                                  std::vector<type_ptr> && arg_types = {});
+        [[nodiscard]] std::shared_ptr<ast::function_type>
+        find_function_type(type_ptr return_type, std::vector<type_ptr> && arg_types = {});
+
         [[nodiscard]] std::shared_ptr<ast::struct_type>
         find_struct_type(std::string && name, const std::string & module_name,
                          std::vector<struct_type::field_type> && fields);

--- a/src/ast_to_cfg.cpp
+++ b/src/ast_to_cfg.cpp
@@ -395,7 +395,7 @@ void ast_to_cfg::visit(ast::func_call_stmt & func_call_stmt) { return visit(func
 
 void ast_to_cfg::visit(ast::func_decl & func_decl) {
     auto & func_start = result_cfg->create_root<control_flow::function_start>(
-        func_decl.name, func_decl.param_count(), func_decl.exported(), func_decl.func_type());
+        func_decl.name, func_decl.param_count(), func_decl.exported(), func_decl.func_type);
     current_function = &func_start;
 
     func_start.parameter_names.reserve(func_start.arg_count);

--- a/src/ast_to_cfg.hpp
+++ b/src/ast_to_cfg.hpp
@@ -4,6 +4,7 @@
 #include "ast/visitor_base.hpp"
 #include "control_flow/graph.hpp"
 #include "control_flow/node.hpp"
+#include "global_map.hpp"
 #include "move_copy.hpp"
 #include "utils/scoped_map.hpp"
 #include "utils/value_getter.hpp"

--- a/src/cfg_to_llvm.cpp
+++ b/src/cfg_to_llvm.cpp
@@ -317,9 +317,9 @@ void cfg_to_llvm::visit(control_flow::function_start & func_start) {
     param_types.reserve(func_start.arg_count);
 
     for (auto i = 0U; i < func_start.arg_count; ++i) {
-        auto ast_type = func_start.type->arg(i);
+        auto * ast_type = func_start.type->arg(i);
         auto * llvm_param_type = type_context.lower_to_llvm(ast_type);
-        if (dynamic_cast<ast::struct_type *>(ast_type.get()) != nullptr) {
+        if (dynamic_cast<ast::struct_type *>(ast_type) != nullptr) {
             // All structs need to be passed as pointers
             llvm_param_type = llvm_param_type->getPointerTo();
         }

--- a/src/cfg_to_llvm.cpp
+++ b/src/cfg_to_llvm.cpp
@@ -313,21 +313,9 @@ void cfg_to_llvm::visit(control_flow::function_end & func_end) {
 
 void cfg_to_llvm::visit(control_flow::function_start & func_start) {
 
-    std::vector<llvm::Type *> param_types;
-    param_types.reserve(func_start.arg_count);
-
-    for (auto i = 0U; i < func_start.arg_count; ++i) {
-        auto * ast_type = func_start.type->arg(i);
-        auto * llvm_param_type = type_lowering.lower_to_llvm(ast_type);
-        if (dynamic_cast<ast::struct_type *>(ast_type) != nullptr) {
-            // All structs need to be passed as pointers
-            llvm_param_type = llvm_param_type->getPointerTo();
-        }
-        param_types.push_back(llvm_param_type);
-    }
-
-    auto * func_type = llvm::FunctionType::get(
-        type_lowering.lower_to_llvm(func_start.type->return_type()), param_types, false);
+    auto * func_type
+        = llvm::cast_or_null<llvm::FunctionType>(type_lowering.lower_to_llvm(func_start.type));
+    assert(func_type != nullptr);
 
     // The only functions that need ExternalLinkage are "main" or exported ones
     auto linkage = (func_start.name == "main" or func_start.exported)

--- a/src/cfg_to_llvm.cpp
+++ b/src/cfg_to_llvm.cpp
@@ -393,8 +393,10 @@ void cfg_to_llvm::syscall(control_flow::intrinsic_call & intrinsic_call) {
     for (auto * val : args) { param_types.push_back(val->getType()); }
 
     assert(intrinsic_call.type != nullptr);
-    auto * func_type = llvm::FunctionType::get(type_context.lower_to_llvm(intrinsic_call.type),
-                                               param_types, false);
+
+    auto * func_type
+        = llvm::cast_or_null<llvm::FunctionType>(type_context.lower_to_llvm(intrinsic_call.type));
+    assert(func_type != nullptr);
 
     assert(llvm::InlineAsm::Verify(func_type, constraint));
 

--- a/src/cfg_to_llvm.cpp
+++ b/src/cfg_to_llvm.cpp
@@ -392,7 +392,8 @@ void cfg_to_llvm::syscall(control_flow::intrinsic_call & intrinsic_call) {
     param_types.reserve(args.size());
     for (auto * val : args) { param_types.push_back(val->getType()); }
 
-    auto * func_type = llvm::FunctionType::get(type_context.lower_to_llvm(ast::prim_type::int32),
+    assert(intrinsic_call.type != nullptr);
+    auto * func_type = llvm::FunctionType::get(type_context.lower_to_llvm(intrinsic_call.type),
                                                param_types, false);
 
     assert(llvm::InlineAsm::Verify(func_type, constraint));

--- a/src/cfg_to_llvm.hpp
+++ b/src/cfg_to_llvm.hpp
@@ -59,7 +59,7 @@ class cfg_to_llvm final : public control_flow::visitor {
     std::unique_ptr<llvm::IRBuilderBase> ir_builder;
 
     global_map<std::string, llvm::GlobalObject *> globals;
-    llvm_type_lowering & type_context;
+    llvm_type_lowering & type_lowering;
 
     std::map<const control_flow::node *, node_data> values;
     std::map<std::string, void (cfg_to_llvm::*)(control_flow::intrinsic_call &)> intrinsics;

--- a/src/control_flow/node.hpp
+++ b/src/control_flow/node.hpp
@@ -132,6 +132,7 @@ namespace control_flow {
         node * previous{nullptr};
         node * next{nullptr};
         std::string name;
+        std::shared_ptr<ast::function_type> type;
         std::vector<node *> arguments;
     };
 

--- a/src/control_flow/node.hpp
+++ b/src/control_flow/node.hpp
@@ -40,9 +40,8 @@ namespace control_flow {
 
     class function_start final : public node {
       public:
-        function_start(std::string name, size_t arg_count, bool exported,
-                       std::shared_ptr<ast::function_type> type)
-            : type{std::move(type)}
+        function_start(std::string name, size_t arg_count, bool exported, ast::function_type * type)
+            : type{type}
             , name{std::move(name)}
             , arg_count{arg_count}
             , exported{exported} {}
@@ -55,7 +54,7 @@ namespace control_flow {
 
         // Invariant: cannot be null
         node * next{nullptr};
-        std::shared_ptr<ast::function_type> type;
+        ast::function_type * type;
         std::vector<std::string> parameter_names;
         std::string name;
         size_t arg_count;
@@ -132,7 +131,7 @@ namespace control_flow {
         node * previous{nullptr};
         node * next{nullptr};
         std::string name;
-        std::shared_ptr<ast::function_type> type;
+        ast::function_type * type{nullptr};
         std::vector<node *> arguments;
     };
 

--- a/src/control_flow/type_checker.cpp
+++ b/src/control_flow/type_checker.cpp
@@ -46,6 +46,7 @@ namespace control_flow {
         auto int_type = type_context.create_type<ast::prim_type>(ast::prim_type::type::int32);
 
         bool first = true;
+        std::vector<ast::type_ptr> arg_types;
         for (auto * arg : call.arguments) {
             auto arg_type = find_type_of(arg);
             if (not arg_type->is_pointer_type() and arg_type != int_type) {
@@ -60,7 +61,11 @@ namespace control_flow {
                                *arg_type);
                 }
             }
+
+            arg_types.push_back(std::move(arg_type));
         }
+
+        call.type = type_context.create_type<ast::function_type>(int_type, std::move(arg_types));
 
         // TODO: syscalls can return pointers and 64 bit numbers
         bind_type(&call, int_type);

--- a/src/control_flow/type_checker.hpp
+++ b/src/control_flow/type_checker.hpp
@@ -32,16 +32,16 @@ namespace control_flow {
         void syscall(control_flow::intrinsic_call & call);
 
         void bind_identifier(std::string name, ast::type * type);
-        void bind_type(control_flow::node * value, ast::type * type);
-        ast::type * find_type_of(control_flow::node * value) const;
+        void bind_type(control_flow::node * value, ast::type_ptr type);
+        ast::type_ptr find_type_of(control_flow::node * value) const;
 
         ast::type_context & type_context;
 
         using instrinic_checker = void (type_checker::*)(intrinsic_call &);
         std::map<std::string, instrinic_checker> intrinsics;
 
-        std::map<std::string, ast::type *> bound_identifiers;
-        std::map<control_flow::node *, ast::type *> node_type;
+        std::map<std::string, ast::type_ptr> bound_identifiers;
+        std::map<control_flow::node *, ast::type_ptr> node_type;
         std::unordered_set<control_flow::node *> visited;
         const ast::type * current_return_type{nullptr};
         bool has_seen_error{false};

--- a/src/control_flow/type_checker.hpp
+++ b/src/control_flow/type_checker.hpp
@@ -1,6 +1,7 @@
 #ifndef CFG_TYPE_CHECKER_HPP
 #define CFG_TYPE_CHECKER_HPP
 
+#include "ast/type_context.hpp"
 #include "control_flow/visitor.hpp"
 
 #include <unordered_set>
@@ -9,11 +10,11 @@ namespace control_flow {
     class type_checker final : public visitor {
 
       public:
-        type_checker();
+        type_checker(ast::type_context & ty_context);
         ~type_checker() noexcept override = default;
 
         non_copyable(type_checker);
-        movable(type_checker);
+        non_movable(type_checker);
 
         [[nodiscard]] bool checked_good() const noexcept { return not has_seen_error; }
 
@@ -33,6 +34,8 @@ namespace control_flow {
         void bind_identifier(std::string name, ast::type * type);
         void bind_type(control_flow::node * value, ast::type * type);
         ast::type * find_type_of(control_flow::node * value) const;
+
+        ast::type_context & type_context;
 
         using instrinic_checker = void (type_checker::*)(intrinsic_call &);
         std::map<std::string, instrinic_checker> intrinsics;

--- a/src/llvm_type_lowering.cpp
+++ b/src/llvm_type_lowering.cpp
@@ -48,6 +48,22 @@ llvm::Type * llvm_type_lowering::lower_to_llvm(ast::type_ptr type) {
             active_types.emplace(type, llvm_struct_type);
             return llvm_struct_type;
         }
+
+        if (const auto * func_type = dynamic_cast<const ast::function_type *>(type);
+            func_type != nullptr) {
+
+            auto * result_type = lower_to_llvm(func_type->return_type());
+
+            std::vector<llvm::Type *> args;
+            args.reserve(func_type->arg_count());
+            for (auto i = 0U; i < func_type->arg_count(); ++i) {
+                args.emplace_back(lower_to_llvm(func_type->arg(i)));
+            }
+
+            auto * llvm_func_type = llvm::FunctionType::get(result_type, args, false);
+            active_types.emplace(type, llvm_func_type);
+            return llvm_func_type;
+        }
         return nullptr;
     }
     return iter->second;

--- a/src/llvm_type_lowering.cpp
+++ b/src/llvm_type_lowering.cpp
@@ -2,16 +2,24 @@
 
 #include <llvm/IR/DerivedTypes.h>
 
-llvm_type_lowering::llvm_type_lowering(llvm::LLVMContext * context)
-    : active_types{
-        {ast::prim_type::int32, llvm::Type::getInt32Ty(*context)},
-        {ast::prim_type::float32, llvm::Type::getFloatTy(*context)},
-        {ast::prim_type::unit, llvm::Type::getVoidTy(*context)},
-        {ast::prim_type::boolean, llvm::Type::getInt1Ty(*context)},
-        {ast::prim_type::character, llvm::Type::getInt8Ty(*context)},
-        // TODO: Move to a Rust style 2 ptr string instead of a C style null-terminated string
-        {ast::prim_type::str, llvm::Type::getInt8PtrTy(*context)},
-    } {}
+llvm_type_lowering::llvm_type_lowering(ast::type_context & type_context,
+                                       llvm::LLVMContext * context) {
+
+    using prim_inner = ast::prim_type::type;
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::int32),
+                         llvm::Type::getInt32Ty(*context));
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::float32),
+                         llvm::Type::getFloatTy(*context));
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::unit),
+                         llvm::Type::getVoidTy(*context));
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::boolean),
+                         llvm::Type::getInt1Ty(*context));
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::character),
+                         llvm::Type::getInt8Ty(*context));
+    // TODO: Move to a Rust style 2 ptr string instead of a C style null-terminated string
+    active_types.emplace(type_context.create_type<ast::prim_type>(prim_inner::str),
+                         llvm::Type::getInt8PtrTy(*context));
+}
 
 llvm::Type * llvm_type_lowering::lower_to_llvm(ast::type_ptr type) {
 

--- a/src/llvm_type_lowering.cpp
+++ b/src/llvm_type_lowering.cpp
@@ -35,7 +35,7 @@ llvm::Type * llvm_type_lowering::lower_to_llvm(ast::type_ptr type) {
             return pointed_to_type->getPointerTo();
         }
 
-        if (const auto * struct_type = dynamic_cast<const ast::struct_type *>(type.get());
+        if (const auto * struct_type = dynamic_cast<const ast::struct_type *>(type);
             struct_type != nullptr) {
 
             std::vector<llvm::Type *> fields;

--- a/src/llvm_type_lowering.hpp
+++ b/src/llvm_type_lowering.hpp
@@ -2,6 +2,7 @@
 #define TYPE_CONTEXT_HPP
 
 #include "ast/node_utils.hpp"
+#include "ast/type_context.hpp"
 #include "utils/global_map.hpp"
 
 #include <map>
@@ -11,7 +12,7 @@
 
 class llvm_type_lowering final {
   public:
-    explicit llvm_type_lowering(llvm::LLVMContext * context);
+    llvm_type_lowering(ast::type_context & type_context, llvm::LLVMContext * context);
 
     [[nodiscard]] llvm::Type * lower_to_llvm(ast::type_ptr type);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,8 @@ int main(const int arg_count, const char * const * const args) {
         = load_modules(filename, type_context, command_line->flag_is_set(cmd_flag::debug_ast));
 
     assert(not modules.empty());
-    auto opt_program = program::from_modules(filename, std::move(modules), command_line);
+    auto opt_program
+        = program::from_modules(filename, std::move(modules), type_context, command_line);
     if (not opt_program.has_value()) { return 1; }
 
     auto program = std::move(opt_program).value();

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -128,7 +128,7 @@ program::program(std::vector<ast::top_level_sequence> && modules, ast::type_cont
     , settings{std::move(settings)}
     , ast_modules(std::move(modules))
     , ty_context(&ty_context)
-    , typ_context{ty_context, context.get()} {}
+    , llvm_lowering{ty_context, context.get()} {}
 
 void program::lower_to_cfg() {
     ast_to_cfg lowering;
@@ -158,7 +158,7 @@ bool program::type_check() {
 
 void program::generate_ir() {
     global_map<std::string, llvm::GlobalObject *> globals;
-    cfg_to_llvm code_generator{"a.out", *context, globals, typ_context};
+    cfg_to_llvm code_generator{"a.out", *context, globals, llvm_lowering};
     cfg->for_each_root(
         [&code_generator](auto * root) { code_generator.control_flow::visitor::visit(*root); });
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -127,6 +127,7 @@ program::program(std::vector<ast::top_level_sequence> && modules, ast::type_cont
     , context{std::make_unique<llvm::LLVMContext>()}
     , settings{std::move(settings)}
     , ast_modules(std::move(modules))
+    , ty_context(&ty_context)
     , typ_context{ty_context, context.get()} {}
 
 void program::lower_to_cfg() {
@@ -145,7 +146,7 @@ void program::lower_to_cfg() {
 
 bool program::type_check() {
     // TODO: Add the program globals from the env pseudo-module
-    control_flow::type_checker checker;
+    control_flow::type_checker checker{*ty_context};
 
     cfg->for_each_root([&checker](auto * root) {
         assert(root != nullptr);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -82,6 +82,7 @@ program::~program() noexcept = default;
 
 std::optional<program> program::from_modules(const std::string & root_file,
                                              std::vector<ast::top_level_sequence> && modules,
+                                             ast::type_context & ty_context,
                                              std::shared_ptr<Settings> settings) {
     // topo sort the modules
     std::map<std::string, std::set<std::string>> dependencies;
@@ -116,17 +117,17 @@ std::optional<program> program::from_modules(const std::string & root_file,
         dest_iter++;
     }
 
-    return program{std::move(modules), std::move(settings),
+    return program{std::move(modules), ty_context, std::move(settings),
                    normalized_absolute_path(root_file).parent_path()};
 }
 
-program::program(std::vector<ast::top_level_sequence> && modules,
+program::program(std::vector<ast::top_level_sequence> && modules, ast::type_context & ty_context,
                  std::shared_ptr<Settings> settings, std::string && project_root)
     : project_root{std::move(project_root)}
     , context{std::make_unique<llvm::LLVMContext>()}
     , settings{std::move(settings)}
     , ast_modules(std::move(modules))
-    , typ_context(context.get()) {}
+    , typ_context{ty_context, context.get()} {}
 
 void program::lower_to_cfg() {
     ast_to_cfg lowering;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -45,6 +45,9 @@ class program final {
     std::vector<ast::top_level_sequence> ast_modules;
     std::unique_ptr<control_flow::graph> cfg;
     std::vector<std::unique_ptr<llvm::Module>> ir_modules;
+    // TODO: Sort out names
+    // HACK: ty_context needs to be a pointer to allow moves
+    ast::type_context * ty_context;
     llvm_type_lowering typ_context;
 };
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -45,10 +45,9 @@ class program final {
     std::vector<ast::top_level_sequence> ast_modules;
     std::unique_ptr<control_flow::graph> cfg;
     std::vector<std::unique_ptr<llvm::Module>> ir_modules;
-    // TODO: Sort out names
     // HACK: ty_context needs to be a pointer to allow moves
     ast::type_context * ty_context;
-    llvm_type_lowering typ_context;
+    llvm_type_lowering llvm_lowering;
 };
 
 #endif

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -2,6 +2,7 @@
 #define PROGRAM_HPP
 
 #include "ast/top_lvl_nodes.hpp"
+#include "ast/type_context.hpp"
 #include "control_flow/graph.hpp"
 #include "llvm_type_lowering.hpp"
 #include "move_copy.hpp"
@@ -16,6 +17,7 @@ class program final {
   public:
     static std::optional<program> from_modules(const std::string & root_file,
                                                std::vector<ast::top_level_sequence> && modules,
+                                               ast::type_context & ty_context,
                                                std::shared_ptr<Settings> settings);
 
     void lower_to_cfg();
@@ -34,8 +36,8 @@ class program final {
     ~program() noexcept;
 
   private:
-    program(std::vector<ast::top_level_sequence> && modules, std::shared_ptr<Settings> settings,
-            std::string && project_root);
+    program(std::vector<ast::top_level_sequence> && modules, ast::type_context & ty_context,
+            std::shared_ptr<Settings> settings, std::string && project_root);
 
     std::string project_root;
     std::unique_ptr<llvm::LLVMContext> context;

--- a/test/ast_to_cfg_test.cpp
+++ b/test/ast_to_cfg_test.cpp
@@ -61,7 +61,8 @@ static void scan_graph(const control_flow::function_start * start,
 
 TEST_CASE("ast_to_cfg can lower an empty function") {
     std::string buffer = "main() {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
     auto mod = parser->parse();
 
     auto lowering = ast_to_cfg{};
@@ -101,7 +102,9 @@ TEST_CASE("ast_to_cfg can lower an empty function") {
 TEST_CASE("ast_to_cfg can lower a shortcircuiting expression") {
     std::string buffer = "positive_even(x : int) = x > 0 and x % 2 == 0";
     std::cout << "Testing " << buffer << std::endl;
-    auto parser = parser::from_buffer(buffer);
+
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
     auto mod = parser->parse();
 
     auto lowering = ast_to_cfg{};

--- a/test/new_parser_test.cpp
+++ b/test/new_parser_test.cpp
@@ -7,7 +7,8 @@
 
 TEST_CASE("the parser will parse braces as a compound statement") {
     std::string buffer = "{}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -19,7 +20,8 @@ TEST_CASE("the parser will parse typed identifiers in both new style and C-style
 
     ast::typed_identifier typed_id_1 = [] {
         std::string buffer = "int x";
-        auto parser = parser::from_buffer(buffer);
+        ast::type_context ty_context;
+        auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
 
@@ -28,7 +30,8 @@ TEST_CASE("the parser will parse typed identifiers in both new style and C-style
 
     ast::typed_identifier typed_id_2 = [] {
         std::string buffer = "x : int";
-        auto parser = parser::from_buffer(buffer);
+        ast::type_context ty_context;
+        auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
 
@@ -43,7 +46,8 @@ TEST_CASE("the parser will parse optionally typed identifiers") {
 
     ast::typed_identifier typed_id_1 = [] {
         std::string buffer = "x";
-        auto parser = parser::from_buffer(buffer);
+        ast::type_context ty_context;
+        auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
 
@@ -52,7 +56,8 @@ TEST_CASE("the parser will parse optionally typed identifiers") {
 
     ast::typed_identifier typed_id_2 = [] {
         std::string buffer = "x : int";
-        auto parser = parser::from_buffer(buffer);
+        ast::type_context ty_context;
+        auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
 
@@ -61,7 +66,8 @@ TEST_CASE("the parser will parse optionally typed identifiers") {
 
     ast::typed_identifier typed_id_3 = [] {
         std::string buffer = "int x";
-        auto parser = parser::from_buffer(buffer);
+        ast::type_context ty_context;
+        auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
 
@@ -74,7 +80,8 @@ TEST_CASE("the parser will parse optionally typed identifiers") {
 
 TEST_CASE("the parser will parse let statement") {
     std::string buffer = "let x = \"hello\";";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -96,7 +103,8 @@ TEST_CASE("the parser will parse let statement") {
 
 TEST_CASE("the parser will parse let statement with types") {
     std::string buffer = "let int x = 10;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -118,7 +126,8 @@ TEST_CASE("the parser will parse let statement with types") {
 
 TEST_CASE("the parser will parse pointer types and expressions") {
     std::string buffer = "let ? int x = null;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -129,7 +138,8 @@ TEST_CASE("the parser will parse pointer types and expressions") {
     auto * let = dynamic_cast<ast::let_stmt *>(stmt.get());
     CHECK(let != nullptr);
     CHECK(let->name_and_type.name() == "x");
-    CHECK(let->name_and_type.type() == ast::nullable_ptr_type::create(ast::prim_type::int32));
+    CHECK(let->name_and_type.type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(let->value != nullptr);
 
     auto * value = dynamic_cast<ast::user_val *>(let->value.get());
@@ -140,7 +150,8 @@ TEST_CASE("the parser will parse pointer types and expressions") {
 
 TEST_CASE("the parser will parse dereferences") {
     std::string buffer = "let x = *y;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -161,7 +172,8 @@ TEST_CASE("the parser will parse dereferences") {
 
 TEST_CASE("the parser will parse unary minus") {
     std::string buffer = "-3";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -182,7 +194,8 @@ TEST_CASE("the parser will parse unary minus") {
 
 TEST_CASE("the parser will parse const declaration") {
     std::string buffer = "const x : int = 5 * -3;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -205,7 +218,8 @@ TEST_CASE("the parser will parse const declaration") {
 
 TEST_CASE("the parser will parse binary expressions") {
     std::string buffer = " 5 + 10 ";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -215,7 +229,8 @@ TEST_CASE("the parser will parse binary expressions") {
 
 TEST_CASE("the parser will parse if expressions") {
     std::string buffer = " if x then y else z + 1 ";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -228,7 +243,8 @@ TEST_CASE("the parser will parse if expressions") {
 
 TEST_CASE("the parser will parse if expressions as atoms") {
     std::string buffer = " 1 + if x then y else z + 1 ";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -244,7 +260,8 @@ TEST_CASE("the parser will parse if expressions as atoms") {
 
 TEST_CASE("the parser will parse if statements") {
     std::string buffer = "if x then {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -263,7 +280,8 @@ TEST_CASE("the parser will parse if statements") {
 
 TEST_CASE("the parser will parse if-else statements") {
     std::string buffer = "if x then {} else {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -282,7 +300,8 @@ TEST_CASE("the parser will parse if-else statements") {
 
 TEST_CASE("the parser will parse return statements") {
     std::string buffer = "return;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -295,7 +314,8 @@ TEST_CASE("the parser will parse return statements") {
 
 TEST_CASE("the parser will parse return statements with values") {
     std::string buffer = "return 5 * 10;";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -314,7 +334,8 @@ TEST_CASE("the parser will parse return statements with values") {
 
 TEST_CASE("the parser will parse function calls as expressions") {
     std::string buffer = "return foo(5, 'x');";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -332,7 +353,8 @@ TEST_CASE("the parser will parse function calls as expressions") {
 
 TEST_CASE("the parser will parse function calls as statements") {
     std::string buffer = "{ foo(5, 'x'); }";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -354,7 +376,8 @@ TEST_CASE("the parser will parse a struct declaration") {
 		y : string,
 		z : bool
 	})";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -371,7 +394,8 @@ TEST_CASE("the parser will parse a struct declaration") {
 
 TEST_CASE("the parser will parse a unit function") {
     std::string buffer = "main() {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -387,7 +411,8 @@ TEST_CASE("the parser will parse a unit function") {
 
 TEST_CASE("the parser will parse a struct initialization") {
     std::string buffer = "let x = my_struct_type { x = 5; y = 6, z = 10, a = 6 / 2 };";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -408,7 +433,8 @@ TEST_CASE("the parser will parse a struct initialization") {
 
 TEST_CASE("the parser will parse a member access") {
     std::string buffer = "x.y.z";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -436,7 +462,8 @@ TEST_CASE("the parser will parse a member access") {
 
 TEST_CASE("the parser will parse a function with return type") {
     std::string buffer = "main() -> int {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -452,7 +479,8 @@ TEST_CASE("the parser will parse a function with return type") {
 
 TEST_CASE("the parser will parse a function with parameters") {
     std::string buffer = "foo(int x, y : bool) -> int {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -472,7 +500,8 @@ TEST_CASE("the parser will parse a function with parameters") {
 
 TEST_CASE("the parser will parse a function with an expression body") {
     std::string buffer = "foo(int x, y : int) -> int = (x + y) / 2";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -503,7 +532,8 @@ factorial(int input) -> int {
 	return input * factorial(input - 1);
 })";
 
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -531,7 +561,8 @@ factorial(int input) -> int {
 
 TEST_CASE("the parser will parse a module with one import") {
     std::string buffer = "from \"test.lil\" import foo, bar; main() {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -552,7 +583,8 @@ TEST_CASE("the parser will parse a module with one import") {
 
 TEST_CASE("the parser will parse imports with or without semicolons") {
     std::string buffer = "from \"test.lil\" import foo, bar\nmain() {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -573,7 +605,8 @@ TEST_CASE("the parser will parse imports with or without semicolons") {
 
 TEST_CASE("the parser will parse a module with multiple imports") {
     std::string buffer = R"(from "test.lil" import foo, bar; from "foo.lil" import baz; main() {})";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -599,7 +632,8 @@ TEST_CASE("the parser will parse a module with multiple imports") {
 
 TEST_CASE("the parser will parse a module with a single export") {
     std::string buffer = "export foo() {}";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 
@@ -620,7 +654,8 @@ TEST_CASE("the parser will parse a module with a single export") {
 
 TEST_CASE("the parser will parse a module with multiple exports") {
     std::string buffer = "export { foo() {}\nconst bar : int = 5 }";
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context ty_context;
+    auto parser = parser::from_buffer(buffer, ty_context);
 
     CHECK(parser != nullptr);
 

--- a/test/new_parser_test.cpp
+++ b/test/new_parser_test.cpp
@@ -115,7 +115,8 @@ TEST_CASE("the parser will parse let statement with types") {
     auto * let = dynamic_cast<ast::let_stmt *>(stmt.get());
     CHECK(let != nullptr);
     CHECK(let->name_and_type.name() == "x");
-    CHECK(let->name_and_type.type() == ast::prim_type::int32);
+    CHECK(let->name_and_type.type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(let->value != nullptr);
 
     auto * value = dynamic_cast<ast::user_val *>(let->value.get());
@@ -206,7 +207,8 @@ TEST_CASE("the parser will parse const declaration") {
     auto * const_decl = dynamic_cast<ast::const_decl *>(decl.get());
     CHECK(const_decl != nullptr);
     CHECK(const_decl->name_and_type.name() == "x");
-    CHECK(const_decl->name_and_type.type() == ast::prim_type::int32);
+    CHECK(const_decl->name_and_type.type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(const_decl->expr != nullptr);
 
     auto * value = dynamic_cast<ast::binary_expr *>(const_decl->expr.get());
@@ -405,7 +407,8 @@ TEST_CASE("the parser will parse a unit function") {
 
     CHECK(func->name == "main");
     CHECK(func->param_count() == 0);
-    CHECK(func->func_type->return_type() == ast::prim_type::unit);
+    CHECK(func->func_type->return_type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::unit));
     CHECK(func->body != nullptr);
 }
 
@@ -473,7 +476,8 @@ TEST_CASE("the parser will parse a function with return type") {
 
     CHECK(func->name == "main");
     CHECK(func->param_count() == 0);
-    CHECK(func->func_type->return_type() == ast::prim_type::int32);
+    CHECK(func->func_type->return_type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(func->body != nullptr);
 }
 
@@ -491,10 +495,13 @@ TEST_CASE("the parser will parse a function with parameters") {
     CHECK(func->name == "foo");
     CHECK(func->param_count() == 2);
     CHECK(func->params[0].name() == "x");
-    CHECK(func->params[0].type() == ast::prim_type::int32);
+    CHECK(func->params[0].type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(func->params[1].name() == "y");
-    CHECK(func->params[1].type() == ast::prim_type::boolean);
-    CHECK(func->func_type->return_type() == ast::prim_type::int32);
+    CHECK(func->params[1].type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::boolean));
+    CHECK(func->func_type->return_type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(func->body != nullptr);
 }
 
@@ -511,7 +518,8 @@ TEST_CASE("the parser will parse a function with an expression body") {
 
     CHECK(func->name == "foo");
     CHECK(func->param_count() == 2);
-    CHECK(func->func_type->return_type() == ast::prim_type::int32);
+    CHECK(func->func_type->return_type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(func->body != nullptr);
 
     auto * ret_stmt = dynamic_cast<ast::return_stmt *>(func->body.get());
@@ -544,8 +552,10 @@ factorial(int input) -> int {
     CHECK(func->name == "factorial");
     CHECK(func->param_count() == 1);
     CHECK(func->params[0].name() == "input");
-    CHECK(func->params[0].type() == ast::prim_type::int32);
-    CHECK(func->func_type->return_type() == ast::prim_type::int32);
+    CHECK(func->params[0].type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
+    CHECK(func->func_type->return_type()
+          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
     CHECK(func->body != nullptr);
 
     auto * body = dynamic_cast<ast::stmt_sequence *>(func->body.get());

--- a/test/new_parser_test.cpp
+++ b/test/new_parser_test.cpp
@@ -405,7 +405,7 @@ TEST_CASE("the parser will parse a unit function") {
 
     CHECK(func->name == "main");
     CHECK(func->param_count() == 0);
-    CHECK(func->ret_type == ast::prim_type::unit);
+    CHECK(func->func_type->return_type() == ast::prim_type::unit);
     CHECK(func->body != nullptr);
 }
 
@@ -473,7 +473,7 @@ TEST_CASE("the parser will parse a function with return type") {
 
     CHECK(func->name == "main");
     CHECK(func->param_count() == 0);
-    CHECK(func->ret_type == ast::prim_type::int32);
+    CHECK(func->func_type->return_type() == ast::prim_type::int32);
     CHECK(func->body != nullptr);
 }
 
@@ -494,7 +494,7 @@ TEST_CASE("the parser will parse a function with parameters") {
     CHECK(func->params[0].type() == ast::prim_type::int32);
     CHECK(func->params[1].name() == "y");
     CHECK(func->params[1].type() == ast::prim_type::boolean);
-    CHECK(func->ret_type == ast::prim_type::int32);
+    CHECK(func->func_type->return_type() == ast::prim_type::int32);
     CHECK(func->body != nullptr);
 }
 
@@ -511,7 +511,7 @@ TEST_CASE("the parser will parse a function with an expression body") {
 
     CHECK(func->name == "foo");
     CHECK(func->param_count() == 2);
-    CHECK(func->ret_type == ast::prim_type::int32);
+    CHECK(func->func_type->return_type() == ast::prim_type::int32);
     CHECK(func->body != nullptr);
 
     auto * ret_stmt = dynamic_cast<ast::return_stmt *>(func->body.get());
@@ -545,7 +545,7 @@ factorial(int input) -> int {
     CHECK(func->param_count() == 1);
     CHECK(func->params[0].name() == "input");
     CHECK(func->params[0].type() == ast::prim_type::int32);
-    CHECK(func->ret_type == ast::prim_type::int32);
+    CHECK(func->func_type->return_type() == ast::prim_type::int32);
     CHECK(func->body != nullptr);
 
     auto * body = dynamic_cast<ast::stmt_sequence *>(func->body.get());

--- a/test/serializer_test.cpp
+++ b/test/serializer_test.cpp
@@ -17,7 +17,8 @@ TEST_CASE("serializer handles hello world") {
 	}
 	)";
 
-    auto parser = parser::from_buffer(buffer);
+    ast::type_context type_context;
+    auto parser = parser::from_buffer(buffer, type_context);
     REQUIRE(parser != nullptr);
 
     auto mod = parser->parse();


### PR DESCRIPTION
This patch moves all ownership of the `ast::type` inheritance tree into `ast::type_context`.