### PR TITLE
Simplify program

### DIFF
--- a/src/cfg_to_llvm.hpp
+++ b/src/cfg_to_llvm.hpp
@@ -32,14 +32,15 @@ class cfg_to_llvm final : public control_flow::visitor {
     void verify_module() const;
     void dump() const;
 
+    [[nodiscard]] std::unique_ptr<llvm::Module> take_ir_module() && noexcept {
+        return std::move(ir_module);
+    }
+
   private:
     // clang-format off
 #define expand_node_macro(name) void visit(control_flow::name & name) override;
         all_cfg_nodes
 #undef expand_node_macro
-
-        std::unique_ptr<llvm::Module> take_ir_module() && noexcept { return std::move(ir_module); }
-    // clang-format on
 
     struct node_data {
         llvm::Value * value;
@@ -47,6 +48,8 @@ class cfg_to_llvm final : public control_flow::visitor {
 
         node_data(llvm::IRBuilderBase & builder, llvm::Value * val);
     };
+    // clang-format on
+
     void bind_value(const control_flow::node & node, llvm::Value * value);
     [[nodiscard]] const node_data * find_value_of(const control_flow::node * node) const;
 

--- a/src/control_flow/graph.hpp
+++ b/src/control_flow/graph.hpp
@@ -44,13 +44,13 @@ namespace control_flow {
         }
 
         template<typename Callable>
-        void for_each_root(Callable func) const noexcept {
-            for (const auto * root : roots) { func(root); }
+        void for_each_function(Callable func) const noexcept {
+            for (const auto * function : roots) { func(function); }
         }
 
         template<typename Callable>
-        void for_each_root(Callable func) noexcept {
-            for (auto * root : roots) { func(root); }
+        void for_each_function(Callable func) noexcept {
+            for (auto * function : roots) { func(function); }
         }
 
         template<typename Callable>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,7 @@ int main(const int arg_count, const char * const * const args) {
 
     const auto & filename = command_line->file_to_read;
 
-    // TODO: Main should not be making a type_context
-    ast::type_context type_context;
-    auto program = program::from_root_file(filename, type_context, command_line);
+    auto program = program::from_root_file(filename, command_line);
 
     if (program == nullptr) { return 1; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include "program.hpp"
-#include "settings.hpp"
+#include "settings.hpp"      // read_settings
 #include "utils/execute.hpp" // exec_command
 
 #include <iostream> // cout

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,7 +14,7 @@ int main(const int arg_count, const char * const * const args) {
 
     if (program == nullptr) { return 1; }
 
-    program->lower_to_cfg();
+    program->lower_to_control_flow_graph();
     if (not program->type_check()) { return 2; }
     program->generate_ir();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,72 +1,8 @@
-#include "ast/parser.hpp"
-#include "ast/serializer.hpp"
 #include "program.hpp"
 #include "settings.hpp"
-#include "utils/execute.hpp"      // exec_command
-#include "utils/string_utils.hpp" // normalized_absolute_path
+#include "utils/execute.hpp" // exec_command
 
-#include <cassert>
 #include <iostream> // cout
-#include <queue>
-#include <set>
-#include <vector>
-
-static std::unique_ptr<ast::top_level_sequence>
-read_module(const std::string & filename, const std::filesystem::path & project_root,
-            ast::type_context & type_context) {
-    auto parser = parser::from_file(filename, project_root, type_context);
-    if (parser == nullptr) { return nullptr; }
-
-    auto module_ = parser->parse();
-    if (module_ == nullptr) { std::cerr << parser->error_message() << std::endl; }
-    return module_;
-}
-
-static std::vector<ast::top_level_sequence>
-load_modules(const std::string & input, ast::type_context & type_context, bool debug_ast) {
-
-    std::vector<ast::top_level_sequence> modules;
-
-    std::set<std::string> loaded;
-    std::queue<std::string> to_load;
-
-    auto proper_input = normalized_absolute_path(input);
-    const auto project_root = proper_input.parent_path();
-
-    to_load.push(std::move(proper_input));
-
-    while (not to_load.empty()) {
-
-        auto filename = to_load.front();
-        to_load.pop();
-
-        // do not double load files
-        if (loaded.find(filename) != loaded.end()) { continue; }
-
-        auto parsed_module = read_module(filename, project_root, type_context);
-        if (parsed_module == nullptr) {
-            std::cout << "Failed to parse " << filename << std::endl;
-            assert(false);
-        }
-
-        parsed_module->filename = unquote(filename);
-
-        if (debug_ast) { ast::serializer::into_stream(std::cout, filename, *parsed_module, true); }
-
-        for (const auto & iter : parsed_module->imports) {
-            // certain modules are "pseudo" (only containing intrinsics)
-            if (iter.first == "env") { continue; }
-
-            to_load.push(project_root / unquote(iter.first));
-        }
-
-        modules.push_back(std::move(*parsed_module));
-        parsed_module.reset();
-        loaded.insert(std::move(filename));
-    }
-
-    return modules;
-}
 
 int main(const int arg_count, const char * const * const args) {
 
@@ -76,27 +12,22 @@ int main(const int arg_count, const char * const * const args) {
 
     // TODO: Main should not be making a type_context
     ast::type_context type_context;
-    auto modules
-        = load_modules(filename, type_context, command_line->flag_is_set(cmd_flag::debug_ast));
+    auto program = program::from_root_file(filename, type_context, command_line);
 
-    assert(not modules.empty());
-    auto opt_program
-        = program::from_modules(filename, std::move(modules), type_context, command_line);
-    if (not opt_program.has_value()) { return 1; }
+    if (program == nullptr) { return 1; }
 
-    auto program = std::move(opt_program).value();
-    program.lower_to_cfg();
-    if (not program.type_check()) { return 2; }
-    program.generate_ir();
+    program->lower_to_cfg();
+    if (not program->type_check()) { return 2; }
+    program->generate_ir();
 
     if (command_line->flag_is_set(cmd_flag::no_output)) { return 0; }
 
     if (command_line->flag_is_set(cmd_flag::simulate)) {
-        std::cout << "Return value: " << program.jit() << std::endl;
+        std::cout << "Return value: " << program->jit() << std::endl;
         return 0;
     }
 
-    auto program_name = program.emit_and_link();
+    auto program_name = program->emit_and_link();
     if (command_line->flag_is_set(cmd_flag::run_result)) {
         auto args = std::vector{program_name};
         std::copy(command_line->extra_args.begin(), command_line->extra_args.end(),

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -81,18 +81,19 @@ read_module(const std::string & filename, const std::filesystem::path & project_
     return module_;
 }
 
+// Breadth first search to load the full module graph
 static std::vector<ast::top_level_sequence>
-load_modules(const std::string & input, ast::type_context & type_context, bool debug_ast) {
+load_modules(const std::string & root_filename, ast::type_context & type_context, bool debug_ast) {
 
     std::vector<ast::top_level_sequence> modules;
 
     std::set<std::string> loaded;
     std::queue<std::string> to_load;
 
-    auto proper_input = normalized_absolute_path(input);
-    const auto project_root = proper_input.parent_path();
+    auto proper_root_name = normalized_absolute_path(root_filename);
+    const auto project_root = proper_root_name.parent_path();
 
-    to_load.push(std::move(proper_input));
+    to_load.push(std::move(proper_root_name));
 
     while (not to_load.empty()) {
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -207,7 +207,7 @@ bool program::type_check() {
     // TODO: Add the program globals from the env pseudo-module
     control_flow::type_checker checker{*ty_context};
 
-    cfg->for_each_root([&checker](auto * root) {
+    cfg->for_each_function([&checker](auto * root) {
         assert(root != nullptr);
         // TODO: Do not require the name lookup for visit
         checker.control_flow::visitor::visit(*root);
@@ -218,7 +218,7 @@ bool program::type_check() {
 void program::generate_ir() {
     global_map<std::string, llvm::GlobalObject *> globals;
     cfg_to_llvm code_generator{"a.out", *context, globals, llvm_lowering};
-    cfg->for_each_root(
+    cfg->for_each_function(
         [&code_generator](auto * root) { code_generator.control_flow::visitor::visit(*root); });
 
     if (settings->flag_is_set(cmd_flag::debug_ir)) { code_generator.dump(); }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -185,7 +185,7 @@ program::program(std::vector<ast::top_level_sequence> && modules,
     , ty_context{std::move(ty_context)}
     , llvm_lowering{*this->ty_context, context.get()} {}
 
-void program::lower_to_cfg() {
+void program::lower_to_control_flow_graph() {
     ast_to_cfg lowering;
 
     for (auto & mod : ast_modules) {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -76,10 +76,6 @@ toposort(const std::string & root, const std::map<std::string, std::set<std::str
     return to_ret;
 }
 
-program::program(program &&) noexcept = default;
-program & program::operator=(program &&) noexcept = default;
-program::~program() noexcept = default;
-
 static std::unique_ptr<ast::top_level_sequence>
 read_module(const std::string & filename, const std::filesystem::path & project_root,
             ast::type_context & type_context) {
@@ -185,6 +181,8 @@ std::unique_ptr<program> program::from_root_file(const std::string & root_filena
         new program{std::move(modules), ty_context, std::move(settings),
                     normalized_absolute_path(root_filename).parent_path()}};
 }
+
+program::~program() noexcept = default;
 
 program::program(std::vector<ast::top_level_sequence> && modules, ast::type_context & ty_context,
                  std::shared_ptr<Settings> settings, std::string && project_root)

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -200,7 +200,8 @@ void program::lower_to_control_flow_graph() {
     }
 
     this->cfg = std::move(lowering).take_cfg();
-    cfg->list_all_nodes();
+
+    if (settings->flag_is_set(cmd_flag::debug_cfg)) { cfg->list_all_nodes(); }
 }
 
 bool program::type_check() {

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -28,9 +28,6 @@ toposort(const std::string & root, const std::map<std::string, std::set<std::str
 
     while (not eval_stack.empty()) {
         auto & current = eval_stack.back();
-        // fmt::print("\nstack size: {}\nstack: {}\nevaluating {}\n",
-        //         eval_stack.size(), eval_stack, current);
-        // if (not to_ret.empty()) fmt::print("result: {}\n", to_ret);
 
         if (contains(to_ret, current)) {
             eval_stack.pop_back();
@@ -42,7 +39,6 @@ toposort(const std::string & root, const std::map<std::string, std::set<std::str
         if (iter == graph.end() or iter->second.empty()) {
             // we can return ourselves now
             to_ret.push_back(current);
-            // fmt::print("pushing {}\n", current);
             eval_stack.pop_back();
             continue;
         }
@@ -52,15 +48,10 @@ toposort(const std::string & root, const std::map<std::string, std::set<std::str
         for (const auto & item : iter->second) {
             if (contains(to_ret, item)) { continue; }
 
-            // fmt::print("could not find {}\n", item);
-            //
             // the item is not in the return list
             // however, there may be a cycle.
             // we need to check that we are not in the eval_stack already
-            if (contains(eval_stack, item)) {
-                // fmt::print("Cycle found: {}\n", eval_stack);
-                return {};
-            }
+            if (contains(eval_stack, item)) { return {}; }
 
             eval_stack.push_back(item);
             pushed_items = true;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -24,7 +24,7 @@ class program final {
     static std::unique_ptr<program> from_root_file(const std::string & root_filename,
                                                    std::shared_ptr<Settings> settings);
 
-    void lower_to_cfg();
+    void lower_to_control_flow_graph();
     [[nodiscard]] bool type_check();
     void generate_ir();
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -29,10 +29,9 @@ class program final {
     [[nodiscard]] uint64_t jit();
 
     non_copyable(program);
+    non_movable(program);
 
-    // These need to be out of line for LLVM types
-    program(program &&) noexcept;
-    program & operator=(program &&) noexcept;
+    // This needs to be out of line for the llvm types.
     ~program() noexcept;
 
   private:

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -17,7 +17,6 @@ class program final {
     // Load all of the required files for one root file, which should have `main` in it.
     // Using a `unique_ptr` will allow `program` to be non-movable.
     static std::unique_ptr<program> from_root_file(const std::string & root_filename,
-                                                   ast::type_context & ty_context,
                                                    std::shared_ptr<Settings> settings);
 
     void lower_to_cfg();
@@ -35,8 +34,9 @@ class program final {
     ~program() noexcept;
 
   private:
-    program(std::vector<ast::top_level_sequence> && modules, ast::type_context & ty_context,
-            std::shared_ptr<Settings> settings, std::string && project_root);
+    program(std::vector<ast::top_level_sequence> && modules,
+            std::unique_ptr<ast::type_context> ty_context, std::shared_ptr<Settings> settings,
+            std::string && project_root);
 
     std::string project_root;
     std::unique_ptr<llvm::LLVMContext> context;
@@ -44,8 +44,7 @@ class program final {
     std::vector<ast::top_level_sequence> ast_modules;
     std::unique_ptr<control_flow::graph> cfg;
     std::vector<std::unique_ptr<llvm::Module>> ir_modules;
-    // HACK: ty_context needs to be a pointer to allow moves
-    ast::type_context * ty_context;
+    std::unique_ptr<ast::type_context> ty_context;
     llvm_type_lowering llvm_lowering;
 };
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -8,17 +8,17 @@
 #include "move_copy.hpp"
 #include "settings.hpp"
 
-#include <optional>
 #include <vector>
 
 #include <llvm/IR/LLVMContext.h>
 
 class program final {
   public:
-    static std::optional<program> from_modules(const std::string & root_file,
-                                               std::vector<ast::top_level_sequence> && modules,
-                                               ast::type_context & ty_context,
-                                               std::shared_ptr<Settings> settings);
+    // Load all of the required files for one root file, which should have `main` in it.
+    // Using a `unique_ptr` will allow `program` to be non-movable.
+    static std::unique_ptr<program> from_root_file(const std::string & root_filename,
+                                                   ast::type_context & ty_context,
+                                                   std::shared_ptr<Settings> settings);
 
     void lower_to_cfg();
     [[nodiscard]] bool type_check();

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -8,9 +8,14 @@
 #include "move_copy.hpp"
 #include "settings.hpp"
 
+#include <memory> // shared_ptr, unique_ptr
 #include <vector>
 
-#include <llvm/IR/LLVMContext.h>
+// Forward declare LLVM types
+namespace llvm {
+    class LLVMContext;
+    class Module;
+} // namespace llvm
 
 class program final {
   public:

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,7 +15,8 @@
     flag(debug_optimized_ir) \
     flag(debug_show_execs)   \
     flag(no_output)          \
-    flag(run_result)
+    flag(run_result)         \
+    flag(debug_cfg)
 
 // clang-format on
 
@@ -36,8 +37,9 @@ std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args
     auto cli = lyra::help(print_help) | lyra::opt(print_version)["--version"]["-V"]
              | lyra::opt(run_result)["-r"]["--run"] | lyra::opt(simulate)["--sim"]["--simulate"]
              | lyra::opt(no_output)["--no-output"] | lyra::opt(debug_ast)["--ast"]
-             | lyra::opt(debug_ir)["--llvm"] | lyra::opt(debug_optimized_ir)["--opt-llvm"]
-             | lyra::opt(debug)["--debug"] | lyra::opt(debug_show_execs)["--exec"]
+             | lyra::opt(debug_cfg)["--cfg"] | lyra::opt(debug_ir)["--llvm"]
+             | lyra::opt(debug_optimized_ir)["--opt-llvm"] | lyra::opt(debug)["--debug"]
+             | lyra::opt(debug_show_execs)["--exec"]
              | lyra::arg(settings->file_to_read, "file to read");
 
     // Make a new vector with all the args from before the "--"
@@ -75,12 +77,13 @@ std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args
 	flags
 #undef flag
 
-	if(debug){
-		settings->set_flag(cmd_flag::debug_ast);
-		settings->set_flag(cmd_flag::debug_ir);
-		settings->set_flag(cmd_flag::debug_optimized_ir);
-		settings->set_flag(cmd_flag::debug_show_execs);
-	}
+    if(debug){
+        settings->set_flag(cmd_flag::debug_ast);
+        settings->set_flag(cmd_flag::debug_cfg);
+        settings->set_flag(cmd_flag::debug_ir);
+        settings->set_flag(cmd_flag::debug_optimized_ir);
+        settings->set_flag(cmd_flag::debug_show_execs);
+    }
 
     // clang-format on
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args
 
     auto print_help = false;
     auto print_version = false;
-	auto debug = false;
+    auto debug = false;
     // clang-format on
 
     auto cli = lyra::help(print_help) | lyra::opt(print_version)["--version"]["-V"]
@@ -74,7 +74,7 @@ std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args
 
 // clang-format off
 #define flag(name) if(name) { settings->set_flag(cmd_flag::name); }
-	flags
+    flags
 #undef flag
 
     if(debug){

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -30,6 +30,8 @@ struct Settings {
     std::vector<std::string> extra_args;
 };
 
+// Parse all CLI arguments before the "--".
+// This allows `littlec myfile.lil -- --myflag` to pass `--myflag` to the resulting executable.
 std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args);
 
 #endif

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -14,6 +14,7 @@ enum class cmd_flag : unsigned {
     debug_show_execs = 1 << 4,
     run_result = 1 << 5,
     no_output = 1 << 6,
+    debug_cfg = 1 << 7,
 };
 
 struct Settings {

--- a/test/ast_to_cfg_test.cpp
+++ b/test/ast_to_cfg_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE("ast_to_cfg can lower an empty function") {
     // There should be 1 root.
     const control_flow::function_start * start = nullptr;
     auto root_count = 0U;
-    cfg->for_each_root([&](auto * root) {
+    cfg->for_each_function([&](auto * root) {
         CHECK(root != nullptr);
         ++root_count;
 
@@ -117,7 +117,7 @@ TEST_CASE("ast_to_cfg can lower a shortcircuiting expression") {
     // There should be 1 root.
     const control_flow::function_start * start = nullptr;
     auto root_count = 0U;
-    cfg->for_each_root([&](auto * root) {
+    cfg->for_each_function([&](auto * root) {
         CHECK(root != nullptr);
         ++root_count;
 


### PR DESCRIPTION
The PR moves loading the module graph into `program.cpp`, along with some minor other refactorings in the same file.