### PR TITLE
Move cfg link ptrs to base

### DIFF
--- a/src/ast_to_cfg.cpp
+++ b/src/ast_to_cfg.cpp
@@ -91,10 +91,6 @@ void ast_to_cfg::check_flow() noexcept {
 
     // Fill the map
     result_cfg->for_each_node([&](auto * node) {
-#ifdef DEBUG
-        std::cout << "Node " << std::hex << reinterpret_cast<std::uintptr_t>(node) << ' '
-                  << typeid(*node).name() << std::endl;
-#endif
         if (auto * func_start = dynamic_cast<control_flow::function_start *>(node);
             func_start != nullptr) {
             // No previous to read
@@ -109,10 +105,6 @@ void ast_to_cfg::check_flow() noexcept {
 
         if (auto * value = dynamic_cast<control_flow::constant *>(node); value != nullptr) {
             found_links.push_back({value->previous, value});
-#ifdef DEBUG
-            std::cout << "value = " << print_constant(value) << ' ' << std::hex
-                      << reinterpret_cast<std::uintptr_t>(value) << std::endl;
-#endif
             return;
         }
 
@@ -128,12 +120,6 @@ void ast_to_cfg::check_flow() noexcept {
 
         if (auto * bin_op = dynamic_cast<control_flow::binary_operation *>(node);
             bin_op != nullptr) {
-#ifdef DEBUG
-            std::cout << "previous to binary_operation: " << std::hex
-                      << reinterpret_cast<std::uintptr_t>(bin_op->previous)
-                      << "\nrhs to binary_operation: "
-                      << reinterpret_cast<std::uintptr_t>(bin_op->rhs) << std::endl;
-#endif
             found_links.push_back({bin_op->previous, bin_op});
             return;
         }

--- a/src/control_flow/node.hpp
+++ b/src/control_flow/node.hpp
@@ -31,6 +31,9 @@ namespace control_flow {
         // Makes `node` the previous of `this`.
         virtual void flows_from(node * node) = 0;
 
+        // Makes `node` the next of `this`.
+        virtual void flows_to(node * node) = 0;
+
       protected:
         node() = default;
     };
@@ -51,6 +54,8 @@ namespace control_flow {
         void flows_from(node * /*node*/) override {
             assert(false and "There is no previous to a function_start");
         }
+
+        void flows_to(node * node) override { next = node; }
 
         // Invariant: cannot be null
         node * next{nullptr};
@@ -74,6 +79,8 @@ namespace control_flow {
             previous = node;
         }
 
+        void flows_to(node * node) override { next = node; }
+
         // Invariant: none of the following `node *` may be null
         node * previous;
         node * next;
@@ -87,6 +94,8 @@ namespace control_flow {
         make_visitable;
 
         void flows_from(node * node) override { previous = node; }
+
+        void flows_to(node * node) override { next = node; }
 
         // Invariant: none of the following `node *` may be null
         node * previous;
@@ -109,6 +118,8 @@ namespace control_flow {
             previous = node;
         }
 
+        void flows_to(node * node) override { next = node; }
+
         std::variant<std::monostate, long, double, char, bool, std::string> value;
         literal_type val_type;
 
@@ -126,6 +137,8 @@ namespace control_flow {
         make_visitable;
 
         void flows_from(node * node) override { previous = node; }
+
+        void flows_to(node * node) override { next = node; }
 
         // Invariant: none of the following `node *` may be null
         node * previous{nullptr};
@@ -145,6 +158,8 @@ namespace control_flow {
 
         void flows_from(node * node) override { previous = node; }
 
+        void flows_to(node * node) override { next = node; }
+
         // Invariant: none of the following `node *` may be null
         node * previous{nullptr};
         node * next{nullptr};
@@ -159,6 +174,16 @@ namespace control_flow {
 
         void flows_from(node * node) override { previous = node; }
 
+        void flows_to(node * node) override {
+            if (true_case != nullptr and false_case != nullptr) { return; }
+
+            if (true_case == nullptr and false_case == nullptr) {
+                assert(false and "branch has a null true and false cases");
+            }
+
+            (true_case == nullptr ? true_case : false_case) = node;
+        }
+
         // Invariant: none of the following `node *` may be null
         node * previous;
         node * condition_value;
@@ -172,6 +197,10 @@ namespace control_flow {
         make_visitable;
 
         void flows_from(node * node) override { previous = node; }
+
+        void flows_to(node * /*node*/) override {
+            assert(false and "function_end cannot have a next");
+        }
 
         // Invariant: `previous` cannot be null
         node * previous;
@@ -190,6 +219,8 @@ namespace control_flow {
                 previous.push_back(node);
             }
         }
+
+        void flows_to(node * node) override { next = node; }
 
         // Invariant: none of the following `node *` may be null
         std::vector<node *> previous;


### PR DESCRIPTION
By adding a `flows_to` helper for control flow nodes, linking the nodes becomes simpler, as the `dynamic_cast` becomes implicit.