### PR TITLE
Parser errors

### DIFF
--- a/src/ast/parser.hpp
+++ b/src/ast/parser.hpp
@@ -13,7 +13,7 @@
 #include <map>
 #include <memory> // unique_ptr
 #include <optional>
-#include <string>
+#include <sstream>
 #include <vector>
 
 #include <move_copy.hpp>
@@ -47,7 +47,9 @@ class parser final {
     [[nodiscard]] std::unique_ptr<ast::top_level_sequence> parse();
 
     // In the case that `parse` failed, `error_message` will provide a human readable error.
-    [[nodiscard]] std::string error_message() const { return error; }
+    // To check that no error has occured in parsing,
+    // ensure that the result of this function is empty.
+    [[nodiscard]] std::string error_message() const { return error_printout.str(); }
 
     // The parser's inner state is rather complex, so not moving or copying it is essential.
     non_copyable(parser);
@@ -125,7 +127,10 @@ class parser final {
 
     lex_ptr lex;
     ast::type_context & ty_context;
-    std::string error;
+    std::stringstream error_printout;
+
+    template<typename... Args>
+    void print_error(Location loc, Args... args);
 };
 
 #endif

--- a/test/new_parser_test.cpp
+++ b/test/new_parser_test.cpp
@@ -18,9 +18,10 @@ TEST_CASE("the parser will parse braces as a compound statement") {
 
 TEST_CASE("the parser will parse typed identifiers in both new style and C-style") {
 
-    ast::typed_identifier typed_id_1 = [] {
+    ast::type_context ty_context;
+
+    ast::typed_identifier typed_id_1 = [&ty_context] {
         std::string buffer = "int x";
-        ast::type_context ty_context;
         auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
@@ -28,9 +29,8 @@ TEST_CASE("the parser will parse typed identifiers in both new style and C-style
         return parser->parse_typed_identifier();
     }();
 
-    ast::typed_identifier typed_id_2 = [] {
+    ast::typed_identifier typed_id_2 = [&ty_context] {
         std::string buffer = "x : int";
-        ast::type_context ty_context;
         auto parser = parser::from_buffer(buffer, ty_context);
 
         CHECK(parser != nullptr);
@@ -139,8 +139,9 @@ TEST_CASE("the parser will parse pointer types and expressions") {
     auto * let = dynamic_cast<ast::let_stmt *>(stmt.get());
     CHECK(let != nullptr);
     CHECK(let->name_and_type.name() == "x");
-    CHECK(let->name_and_type.type()
-          == ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32));
+
+    auto * int_type = ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32);
+    CHECK(let->name_and_type.type() == ty_context.create_type<ast::nullable_ptr_type>(int_type));
     CHECK(let->value != nullptr);
 
     auto * value = dynamic_cast<ast::user_val *>(let->value.get());


### PR DESCRIPTION
Use a `print_error` function, akin to other classes in the codebase.