### PR TITLE
Formatting cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,13 +26,21 @@ AllowShortLoopsOnASingleLine: true
 
 # Where line breaks should be
 AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Attach
+BreakBeforeConceptDeclarations: Always
+BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+ReflowComments: true
+SeparateDefinitionBlocks: Always
+
 DerivePointerAlignment: false
 PointerAlignment: Middle
 
-BreakBeforeBinaryOperators: All
-BreakBeforeTernaryOperators: true
 
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true

--- a/.clang-format
+++ b/.clang-format
@@ -42,6 +42,8 @@ DerivePointerAlignment: false
 PointerAlignment: Middle
 ReferenceAlignment: Pointer
 
+BitFieldColonSpacing: Both
+
 IndentCaseBlocks: false
 IndentCaseLabels: false
 IndentPPDirectives: BeforeHash
@@ -49,6 +51,10 @@ IndentRequires: false
 
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: 10
 
 SortIncludes: true
 SortUsingDeclarations: true

--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,12 @@ SeparateDefinitionBlocks: Always
 
 DerivePointerAlignment: false
 PointerAlignment: Middle
+ReferenceAlignment: Pointer
 
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentPPDirectives: BeforeHash
+IndentRequires: false
 
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true

--- a/.clang-format
+++ b/.clang-format
@@ -9,20 +9,24 @@ UseTab: Never
 MaxEmptyLinesToKeep: 1
 
 # Alignment checks
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignEscapedNewlines: Left
 AlignOperands: AlignAfterOperator
 AlignTrailingComments: true
-AlignAfterOpenBracket: Align
-AlignEscapedNewlines: Left
 
 # Allowed shortenings
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: true
-BreakBeforeBraces: Attach
 
+# Where line breaks should be
 AlwaysBreakTemplateDeclarations: Yes
-
+BreakBeforeBraces: Attach
 BreakConstructorInitializers: BeforeComma
 DerivePointerAlignment: false
 PointerAlignment: Middle

--- a/src/ast/base_nodes.hpp
+++ b/src/ast/base_nodes.hpp
@@ -46,6 +46,7 @@ namespace ast {
     };
 
     class stmt : public virtual node {};
+
     class top_level : public virtual node {
 
       public:

--- a/src/ast/base_nodes.hpp
+++ b/src/ast/base_nodes.hpp
@@ -1,5 +1,4 @@
-#ifndef BASE_NODES_HPP
-#define BASE_NODES_HPP
+#pragma once
 
 #include "location.hpp"
 #include "nodes_forward.hpp"
@@ -71,5 +70,3 @@ namespace ast {
     using stmt_ptr = std::unique_ptr<stmt>;
     using top_lvl_ptr = std::unique_ptr<top_level>;
 } // namespace ast
-
-#endif

--- a/src/ast/expr_nodes.hpp
+++ b/src/ast/expr_nodes.hpp
@@ -1,5 +1,4 @@
-#ifndef EXPR_NODES_HPP
-#define EXPR_NODES_HPP
+#pragma once
 
 #include "base_nodes.hpp"
 #include "location.hpp"
@@ -118,5 +117,3 @@ namespace ast {
         std::vector<std::pair<std::string, ast::expr_ptr>> initializers;
     };
 } // namespace ast
-
-#endif

--- a/src/ast/lexer.cpp
+++ b/src/ast/lexer.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<lexer> lexer::from_file(const std::string & filename) {
 
     // Then, we read the open file's size.
     struct stat file_stats {};
+
     if (fstat(fd, &file_stats) == -1) {
         perror("lexer stat");
         return nullptr;

--- a/src/ast/lexer.cpp
+++ b/src/ast/lexer.cpp
@@ -121,33 +121,33 @@ lexer::token lexer::next_identifier(Location loc) {
     while (isalnum(peek_char()) != 0 or peek_char() == '_') { to_ret += next_char(); }
 
     static const std::map<std::string, lexer::token_type> reserved_words{
-        // alternate tokens
-        {"and", token_type::double_and},
-        {"equals", token_type::eq},
-        {"is", token_type::colon},
-        {"or", token_type::double_or},
-        // keywords
-        {"const", token_type::const_},
-        {"else", token_type::else_},
-        {"export", token_type::export_},
-        {"from", token_type::from},
-        {"if", token_type::if_},
-        {"import", token_type::import_},
-        {"let", token_type::let},
-        {"null", token_type::null},
-        {"ret", token_type::return_},
-        {"return", token_type::return_},
-        {"then", token_type::then},
-        // primitive types
-        {"bool", token_type::prim_type},
-        {"char", token_type::prim_type},
-        {"float", token_type::prim_type},
-        {"int", token_type::prim_type},
-        {"string", token_type::prim_type},
-        {"unit", token_type::prim_type},
-        // literal values
-        {"true", token_type::boolean},
-        {"false", token_type::boolean},
+  // alternate tokens
+        {"and",    token_type::double_and},
+        {"equals", token_type::eq        },
+        {"is",     token_type::colon     },
+        {"or",     token_type::double_or },
+ // keywords
+        {"const",  token_type::const_    },
+        {"else",   token_type::else_     },
+        {"export", token_type::export_   },
+        {"from",   token_type::from      },
+        {"if",     token_type::if_       },
+        {"import", token_type::import_   },
+        {"let",    token_type::let       },
+        {"null",   token_type::null      },
+        {"ret",    token_type::return_   },
+        {"return", token_type::return_   },
+        {"then",   token_type::then      },
+ // primitive types
+        {"bool",   token_type::prim_type },
+        {"char",   token_type::prim_type },
+        {"float",  token_type::prim_type },
+        {"int",    token_type::prim_type },
+        {"string", token_type::prim_type },
+        {"unit",   token_type::prim_type },
+ // literal values
+        {"true",   token_type::boolean   },
+        {"false",  token_type::boolean   },
     };
 
     if (auto iter = reserved_words.find(to_ret); iter != reserved_words.end()) {

--- a/src/ast/lexer.hpp
+++ b/src/ast/lexer.hpp
@@ -1,5 +1,4 @@
-#ifndef LEXER_HPP
-#define LEXER_HPP
+#pragma once
 
 #include "location.hpp"
 
@@ -160,5 +159,3 @@ class lexer final {
 };
 
 using lex_ptr = std::unique_ptr<lexer>;
-
-#endif

--- a/src/ast/lexer.hpp
+++ b/src/ast/lexer.hpp
@@ -86,6 +86,7 @@ class lexer final {
 
       private:
         friend bool operator==(const token & tok, token_type type) { return tok.type == type; }
+
         friend bool operator==(const token & tok, const std::string & text) {
             return tok.text == text;
         }

--- a/src/ast/location.hpp
+++ b/src/ast/location.hpp
@@ -14,6 +14,7 @@ class Location final {
         , column_num{column} {}
 
     [[nodiscard]] constexpr auto line() const noexcept { return line_num; }
+
     [[nodiscard]] constexpr auto column() const noexcept { return column_num; }
 
   private:

--- a/src/ast/location.hpp
+++ b/src/ast/location.hpp
@@ -1,5 +1,4 @@
-#ifndef LOCATION_HPP
-#define LOCATION_HPP
+#pragma once
 
 #include <iosfwd>
 #include <utility>
@@ -38,5 +37,3 @@ class Location final {
 };
 
 std::ostream & operator<<(std::ostream & lhs, const Location & rhs);
-
-#endif

--- a/src/ast/node_utils.hpp
+++ b/src/ast/node_utils.hpp
@@ -1,5 +1,4 @@
-#ifndef NODE_UTILS_HPP
-#define NODE_UTILS_HPP
+#pragma once
 
 #include "base_nodes.hpp"
 #include "location.hpp"
@@ -68,5 +67,3 @@ namespace ast {
         std::vector<expr_ptr> args_{};
     };
 } // namespace ast
-
-#endif

--- a/src/ast/node_utils.hpp
+++ b/src/ast/node_utils.hpp
@@ -23,7 +23,9 @@ namespace ast {
             , loc{loc} {}
 
         [[nodiscard]] const auto & name() const { return name_; }
+
         [[nodiscard]] ast::type_ptr type() const { return type_; }
+
         [[nodiscard]] const auto & location() const noexcept { return loc; }
 
         make_visitable;

--- a/src/ast/nodes.hpp
+++ b/src/ast/nodes.hpp
@@ -1,8 +1,5 @@
-#ifndef AST_NODES_HPP
-#define AST_NODES_HPP
+#pragma once
 
 #include "expr_nodes.hpp"
 #include "stmt_nodes.hpp"
 #include "top_lvl_nodes.hpp"
-
-#endif

--- a/src/ast/nodes_forward.hpp
+++ b/src/ast/nodes_forward.hpp
@@ -1,5 +1,4 @@
-#ifndef NODES_FORWARD_HPP
-#define NODES_FORWARD_HPP
+#pragma once
 
 // clang-format off
 #define ast_nodes                 \
@@ -32,5 +31,3 @@ namespace ast {
     ast_nodes
 #undef expand_node_macro
 } // namespace ast
-
-#endif

--- a/src/ast/parser.cpp
+++ b/src/ast/parser.cpp
@@ -466,23 +466,23 @@ ast::type_ptr parser::parse_type() {
             {"int",
              [this] {
                  return ty_context.create_type<ast::prim_type>(ast::prim_type::type::int32);
-             }},
+             }                                                                                    },
             {"float",
              [this] {
                  return ty_context.create_type<ast::prim_type>(ast::prim_type::type::float32);
-             }},
+             }                                                                                    },
             {"char",
              [this] {
                  return ty_context.create_type<ast::prim_type>(ast::prim_type::type::character);
-             }},
+             }                                                                                    },
             {"unit",
              [this] { return ty_context.create_type<ast::prim_type>(ast::prim_type::type::unit); }},
             {"bool",
              [this] {
                  return ty_context.create_type<ast::prim_type>(ast::prim_type::type::boolean);
-             }},
+             }                                                                                    },
             {"string",
-             [this] { return ty_context.create_type<ast::prim_type>(ast::prim_type::type::str); }},
+             [this] { return ty_context.create_type<ast::prim_type>(ast::prim_type::type::str); } },
         };
         auto iter = prim_types.find(lex->next_token().text);
         if (iter == prim_types.end()) {

--- a/src/ast/parser.hpp
+++ b/src/ast/parser.hpp
@@ -1,5 +1,4 @@
-#ifndef PARSER_HPP
-#define PARSER_HPP
+#pragma once
 
 #include "base_nodes.hpp"
 #include "lexer.hpp"
@@ -132,5 +131,3 @@ class parser final {
     template<typename... Args>
     void print_error(Location loc, Args... args);
 };
-
-#endif

--- a/src/ast/serializer.cpp
+++ b/src/ast/serializer.cpp
@@ -14,8 +14,9 @@ namespace ast {
 
         return store_result(std::map<std::string, nlohmann::json>{
             {"operator", nlohmann::json{token_to_string(binary_expr.op)}},
-            {"lhs", lhs},
-            {"rhs", rhs}});
+            {"lhs",      lhs                                            },
+            {"rhs",      rhs                                            }
+        });
     }
 
     void serializer::visit(top_level_sequence & top_level_sequence) {
@@ -37,10 +38,11 @@ namespace ast {
     void serializer::visit(const_decl & const_decl) {
         auto value = get_value(*const_decl.expr, *this);
 
-        return store_result(
-            nlohmann::json::object_t{{"decl_type", "const"},
-                                     {"variable", get_value(const_decl.name_and_type, *this)},
-                                     {"value", std::move(value)}});
+        return store_result(nlohmann::json::object_t{
+            {"decl_type", "const"},
+            {"variable", get_value(const_decl.name_and_type, *this)},
+            {"value", std::move(value)}
+        });
     }
 
     void serializer::visit(func_call_data & func_call_data) {
@@ -50,8 +52,10 @@ namespace ast {
             args[i] = get_value(func_call_data.arg(i), *this);
         }
 
-        return store_result(std::map<std::string, nlohmann::json>{{"name", func_call_data.name()},
-                                                                  {"args", std::move(args)}});
+        return store_result(std::map<std::string, nlohmann::json>{
+            {"name", func_call_data.name()},
+            {"args", std::move(args)      }
+        });
     }
 
     void serializer::visit(func_call_expr & func_call_expr) { visit(func_call_expr.data); }
@@ -68,10 +72,12 @@ namespace ast {
         assert(func_decl.func_type != nullptr);
         auto return_type = (std::stringstream{} << *func_decl.func_type->return_type()).str();
 
-        return store_result(nlohmann::json::object_t{{"body", std::move(body)},
-                                                     {"name", func_decl.name},
-                                                     {"paramaters", std::move(params)},
-                                                     {"return type", std::move(return_type)}});
+        return store_result(nlohmann::json::object_t{
+            {"body",        std::move(body)       },
+            {"name",        func_decl.name        },
+            {"paramaters",  std::move(params)     },
+            {"return type", std::move(return_type)}
+        });
     }
 
     void serializer::visit(ast::if_expr & if_expr) {
@@ -79,10 +85,11 @@ namespace ast {
         auto then_value = get_value(*if_expr.then_case, *this);
         auto else_value = get_value(*if_expr.else_case, *this);
 
-        return store_result(
-            std::map<std::string, nlohmann::json>{{"condition", std::move(condition)},
-                                                  {"then_value", std::move(then_value)},
-                                                  {"else_value", std::move(else_value)}});
+        return store_result(std::map<std::string, nlohmann::json>{
+            {"condition",  std::move(condition) },
+            {"then_value", std::move(then_value)},
+            {"else_value", std::move(else_value)}
+        });
     }
 
     void serializer::visit(ast::if_stmt & if_stmt) {
@@ -92,25 +99,28 @@ namespace ast {
         auto else_value = if_stmt.else_branch != nullptr ? get_value(*if_stmt.else_branch, *this)
                                                          : nlohmann::json{};
 
-        return store_result(
-            std::map<std::string, nlohmann::json>{{"condition", std::move(condition)},
-                                                  {"then_value", std::move(then_value)},
-                                                  {"else_value", std::move(else_value)}});
+        return store_result(std::map<std::string, nlohmann::json>{
+            {"condition",  std::move(condition) },
+            {"then_value", std::move(then_value)},
+            {"else_value", std::move(else_value)}
+        });
     }
 
     void serializer::visit(ast::let_stmt & let_stmt) {
         auto value = get_value(*let_stmt.value, *this);
 
-        return store_result(
-            nlohmann::json::object_t{{"decl_type", "let"},
-                                     {"variable", get_value(let_stmt.name_and_type, *this)},
-                                     {"value", std::move(value)}});
+        return store_result(nlohmann::json::object_t{
+            {"decl_type", "let"},
+            {"variable", get_value(let_stmt.name_and_type, *this)},
+            {"value", std::move(value)}
+        });
     }
 
     void serializer::visit(ast::return_stmt & return_stmt) {
         return store_result(std::map<std::string, nlohmann::json>{
             {"value",
-             return_stmt.value != nullptr ? get_value(*return_stmt.value, *this) : nullptr}});
+             return_stmt.value != nullptr ? get_value(*return_stmt.value, *this) : nullptr}
+        });
     }
 
     void serializer::visit(ast::stmt_sequence & stmt_sequence) {
@@ -127,8 +137,10 @@ namespace ast {
 
         for (auto & field : struct_decl.fields) { fields.push_back(get_value(field, *this)); }
 
-        return store_result(
-            nlohmann::json::object_t{{"name", struct_decl.name}, {"fields", std::move(fields)}});
+        return store_result(nlohmann::json::object_t{
+            {"name",   struct_decl.name },
+            {"fields", std::move(fields)}
+        });
     }
 
     void serializer::visit(ast::struct_init & struct_init) {
@@ -136,11 +148,16 @@ namespace ast {
         std::vector<nlohmann::json> fields;
 
         for (auto & [name, value] : struct_init.initializers) {
-            fields.emplace_back(
-                nlohmann::json::object_t{{"name", name}, {"value", get_value(*value, *this)}});
+            fields.emplace_back(nlohmann::json::object_t{
+                {"name", name},
+                {"value", get_value(*value, *this)}
+            });
         }
 
-        return store_result({{"type", struct_init.type_name}, {"initializers", std::move(fields)}});
+        return store_result({
+            {"type",         struct_init.type_name},
+            {"initializers", std::move(fields)    }
+        });
     }
 
     void serializer::visit(ast::typed_identifier & typed_identifier) {
@@ -149,17 +166,23 @@ namespace ast {
                       ? nlohmann::json{(std::stringstream{} << typed_identifier.type()).str()}
                       : nlohmann::json{};
 
-        return store_result(
-            nlohmann::json::object_t{{"name", typed_identifier.name()}, {"type", std::move(type)}});
+        return store_result(nlohmann::json::object_t{
+            {"name", typed_identifier.name()},
+            {"type", std::move(type)        }
+        });
     }
 
     void serializer::visit(ast::unary_expr & unary_expr) {
-        return store_result(
-            {{"operator", unary_expr.op}, {"operand", get_value(*unary_expr.expr, *this)}});
+        return store_result({
+            {"operator", unary_expr.op},
+            {"operand", get_value(*unary_expr.expr, *this)}
+        });
     }
 
     void serializer::visit(ast::user_val & user_val) {
-        return store_result(
-            {{"value_type", token_to_string(user_val.val_type)}, {"value", user_val.val}});
+        return store_result({
+            {"value_type", token_to_string(user_val.val_type)},
+            {"value",      user_val.val                      }
+        });
     }
 } // namespace ast

--- a/src/ast/serializer.cpp
+++ b/src/ast/serializer.cpp
@@ -31,8 +31,11 @@ namespace ast {
     // These four should not be called under any circumstance.
     // TODO: Remove from the trick macro.
     void serializer::visit(node & /*node*/) { assert(false and "Should not get here"); }
+
     void serializer::visit(expr & /*expr*/) { assert(false and "Should not get here"); }
+
     void serializer::visit(stmt & /*stmt*/) { assert(false and "Should not get here"); }
+
     void serializer::visit(top_level & /*top_level*/) { assert(false and "Should not get here"); }
 
     void serializer::visit(const_decl & const_decl) {
@@ -59,6 +62,7 @@ namespace ast {
     }
 
     void serializer::visit(func_call_expr & func_call_expr) { visit(func_call_expr.data); }
+
     void serializer::visit(func_call_stmt & func_call_stmt) { visit(func_call_stmt.data); }
 
     void serializer::visit(func_decl & func_decl) {

--- a/src/ast/serializer.hpp
+++ b/src/ast/serializer.hpp
@@ -15,7 +15,10 @@ namespace ast {
         static nlohmann::json to_json(std::string filename, ast::top_level_sequence & mod) {
             ast::serializer serializer;
             serializer.visit(mod);
-            return {{"filename", std::move(filename)}, {"contents", serializer.get_result()}};
+            return {
+                {"filename", std::move(filename)    },
+                {"contents", serializer.get_result()}
+            };
         }
 
         static void into_stream(std::ostream & stream, std::string filename,

--- a/src/ast/serializer.hpp
+++ b/src/ast/serializer.hpp
@@ -9,8 +9,9 @@
 #include <value_getter.hpp>
 
 namespace ast {
-    class serializer : public visitor_base,
-                       public value_getter<serializer, ast::node, nlohmann::json> {
+    class serializer
+        : public visitor_base
+        , public value_getter<serializer, ast::node, nlohmann::json> {
       public:
         static nlohmann::json to_json(std::string filename, ast::top_level_sequence & mod) {
             ast::serializer serializer;

--- a/src/ast/serializer.hpp
+++ b/src/ast/serializer.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_SERIALIZER_HPP
-#define AST_SERIALIZER_HPP
+#pragma once
 
 #include "visitor_base.hpp"
 
@@ -42,5 +41,3 @@ namespace ast {
         // clang-format on
     };
 } // namespace ast
-
-#endif

--- a/src/ast/stmt_nodes.hpp
+++ b/src/ast/stmt_nodes.hpp
@@ -1,5 +1,4 @@
-#ifndef STMT_NODES_HPP
-#define STMT_NODES_HPP
+#pragma once
 
 #include "base_nodes.hpp"
 #include "node_utils.hpp"
@@ -88,5 +87,3 @@ namespace ast {
         expr_ptr value;
     };
 } // namespace ast
-
-#endif

--- a/src/ast/top_lvl_nodes.hpp
+++ b/src/ast/top_lvl_nodes.hpp
@@ -22,6 +22,7 @@ namespace ast {
         make_visitable;
 
         void append(top_lvl_ptr item) { items.emplace_back(std::move(item)); }
+
         void append(std::vector<top_lvl_ptr> && new_items) {
             for (auto && item : new_items) { items.emplace_back(std::move(item)); }
         }

--- a/src/ast/top_lvl_nodes.hpp
+++ b/src/ast/top_lvl_nodes.hpp
@@ -1,5 +1,4 @@
-#ifndef TOP_LVL_NODES_HPP
-#define TOP_LVL_NODES_HPP
+#pragma once
 
 #include "base_nodes.hpp"
 #include "node_utils.hpp"
@@ -110,5 +109,3 @@ namespace ast {
         void update_export(bool /*val*/) final {}
     };
 } // namespace ast
-
-#endif

--- a/src/ast/type.cpp
+++ b/src/ast/type.cpp
@@ -29,12 +29,15 @@ namespace ast {
         assert(not module_name.empty());
 
         return std::unique_ptr<struct_type>{
-            new struct_type{std::move(name), module_name, std::move(fields)}};
+            new struct_type{std::move(name), module_name, std::move(fields)}
+        };
     }
 
     std::unique_ptr<function_type> function_type::create(ast::type_ptr ret_type,
                                                          std::vector<ast::type_ptr> && arg_types) {
-        return std::unique_ptr<function_type>{new function_type{ret_type, std::move(arg_types)}};
+        return std::unique_ptr<function_type>{
+            new function_type{ret_type, std::move(arg_types)}
+        };
     }
 
     // Printing types

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -1,5 +1,4 @@
-#ifndef TYPE_HPP
-#define TYPE_HPP
+#pragma once
 
 #include <iosfwd> // ostream
 #include <memory> // unique_ptr
@@ -196,5 +195,3 @@ namespace ast {
     };
 
 } // namespace ast
-
-#endif

--- a/src/ast/type.hpp
+++ b/src/ast/type.hpp
@@ -25,6 +25,7 @@ namespace ast {
             rhs.print(lhs);
             return lhs;
         }
+
         virtual void print(std::ostream &) const = 0;
     };
 
@@ -33,6 +34,7 @@ namespace ast {
     class ptr_type : public type {
       public:
         [[nodiscard]] virtual bool nullable() const noexcept = 0;
+
         [[nodiscard]] bool is_pointer_type() const final { return true; }
 
         [[nodiscard]] type_ptr pointed_to_type() const { return pointed_to; }
@@ -127,6 +129,7 @@ namespace ast {
         [[nodiscard]] bool is_pointer_type() const final { return false; }
 
         [[nodiscard]] const std::string & containing_module_name() const { return module_name; }
+
         [[nodiscard]] const std::string & user_name() const { return name; }
 
       protected:
@@ -149,6 +152,7 @@ namespace ast {
         ~struct_type() final = default;
 
         [[nodiscard]] size_t field_count() const noexcept { return fields.size(); }
+
         [[nodiscard]] const field_type & field(size_t index) const { return fields[index]; }
 
       private:
@@ -175,7 +179,9 @@ namespace ast {
         [[nodiscard]] bool is_pointer_type() const final { return false; }
 
         [[nodiscard]] size_t arg_count() const noexcept { return arg_types.size(); }
+
         [[nodiscard]] type_ptr arg(size_t index) const { return arg_types[index]; }
+
         [[nodiscard]] type_ptr return_type() const { return ret_type; }
 
       private:

--- a/src/ast/type_context.hpp
+++ b/src/ast/type_context.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_TYPE_CONTEXT_HPP
-#define AST_TYPE_CONTEXT_HPP
+#pragma once
 
 #include "type.hpp"
 
@@ -57,5 +56,3 @@ namespace ast {
         std::vector<std::unique_ptr<ast::type>> types;
     };
 } // namespace ast
-
-#endif

--- a/src/ast/visitor_base.hpp
+++ b/src/ast/visitor_base.hpp
@@ -1,5 +1,4 @@
-#ifndef VISITOR_BASE_HPP
-#define VISITOR_BASE_HPP
+#pragma once
 
 #include "nodes_forward.hpp"
 
@@ -24,5 +23,3 @@ namespace ast {
         // clang-format on
     };
 } // namespace ast
-
-#endif

--- a/src/ast_to_cfg.cpp
+++ b/src/ast_to_cfg.cpp
@@ -178,8 +178,11 @@ void ast_to_cfg::export_if_needed(const ast::top_level & ast_node,
 }
 
 void ast_to_cfg::visit(ast::node & node) { node.accept(*this); }
+
 void ast_to_cfg::visit(ast::top_level & top_level) { top_level.accept(*this); }
+
 void ast_to_cfg::visit(ast::stmt & stmt) { stmt.accept(*this); }
+
 void ast_to_cfg::visit(ast::expr & expr) { expr.accept(*this); }
 
 void ast_to_cfg::import_item(const std::string & id, const std::string & mod) {
@@ -300,6 +303,7 @@ void ast_to_cfg::visit(ast::func_call_data & func_call_data) {
 }
 
 void ast_to_cfg::visit(ast::func_call_expr & func_call_expr) { return visit(func_call_expr.data); }
+
 void ast_to_cfg::visit(ast::func_call_stmt & func_call_stmt) { return visit(func_call_stmt.data); }
 
 void ast_to_cfg::visit(ast::func_decl & func_decl) {

--- a/src/ast_to_cfg.hpp
+++ b/src/ast_to_cfg.hpp
@@ -18,8 +18,9 @@ struct basic_block {
     bool from_id_lookup{false};
 };
 
-class ast_to_cfg final : public ast::visitor_base,
-                         public value_getter<ast_to_cfg, ast::node, basic_block> {
+class ast_to_cfg final
+    : public ast::visitor_base
+    , public value_getter<ast_to_cfg, ast::node, basic_block> {
   public:
     ast_to_cfg();
 

--- a/src/ast_to_cfg.hpp
+++ b/src/ast_to_cfg.hpp
@@ -1,5 +1,4 @@
-#ifndef AST_TO_CFG
-#define AST_TO_CFG
+#pragma once
 
 #include "ast/visitor_base.hpp"
 #include "control_flow/graph.hpp"
@@ -60,5 +59,3 @@ class ast_to_cfg final : public ast::visitor_base,
         globals;
     std::string current_module;
 };
-
-#endif

--- a/src/cfg_to_llvm.cpp
+++ b/src/cfg_to_llvm.cpp
@@ -13,9 +13,14 @@
 
 namespace {
 
-    const std::map<std::string, bool> valid_bools{{"true", true},   {"True", true},
-                                                  {"TRUE", true},   {"false", false},
-                                                  {"False", false}, {"FALSE", false}};
+    const std::map<std::string, bool> valid_bools{
+        {"true",  true },
+        {"True",  true },
+        {"TRUE",  true },
+        {"false", false},
+        {"False", false},
+        {"FALSE", false}
+    };
 
     namespace constraints {
 
@@ -122,14 +127,16 @@ void cfg_to_llvm::visit(control_flow::binary_operation & binary_operation) {
     if (operation::is_shortcircuiting(binary_operation.op)) {
         assert(false);
     } else if (operation::is_comparison(binary_operation.op)) {
-        static constexpr std::array<float_int_op_pair<operand, predicate>, 6> comparison_ops{{
-            {operand::le, predicate::ICMP_SGE, predicate::FCMP_OLE},
-            {operand::lt, predicate::ICMP_SLT, predicate::FCMP_OLT},
-            {operand::ge, predicate::ICMP_SGE, predicate::FCMP_OGE},
-            {operand::gt, predicate::ICMP_SGT, predicate::FCMP_OGT},
-            {operand::eq, predicate::ICMP_EQ, predicate::FCMP_OEQ},
-            {operand::ne, predicate::ICMP_NE, predicate::FCMP_ONE},
-        }};
+        static constexpr std::array<float_int_op_pair<operand, predicate>, 6> comparison_ops{
+            {
+             {operand::le, predicate::ICMP_SGE, predicate::FCMP_OLE},
+             {operand::lt, predicate::ICMP_SLT, predicate::FCMP_OLT},
+             {operand::ge, predicate::ICMP_SGE, predicate::FCMP_OGE},
+             {operand::gt, predicate::ICMP_SGT, predicate::FCMP_OGT},
+             {operand::eq, predicate::ICMP_EQ, predicate::FCMP_OEQ},
+             {operand::ne, predicate::ICMP_NE, predicate::FCMP_ONE},
+             }
+        };
 
         const auto * selected_op
             = find_in(comparison_ops, [op = binary_operation.op](auto & entry) -> bool {
@@ -175,12 +182,14 @@ void cfg_to_llvm::visit(control_flow::binary_operation & binary_operation) {
         using operand = operation::binary;
         using bin_ops = llvm::Instruction::BinaryOps;
 
-        static constexpr std::array<float_int_op_pair<operand, bin_ops>, 4> arithmetic_ops{{
-            {operand::add, bin_ops::Add, bin_ops::FAdd},
-            {operand::sub, bin_ops::Sub, bin_ops::FSub},
-            {operand::mult, bin_ops::Mul, bin_ops::FMul},
-            {operand::div, bin_ops::SDiv, bin_ops::FDiv},
-        }};
+        static constexpr std::array<float_int_op_pair<operand, bin_ops>, 4> arithmetic_ops{
+            {
+             {operand::add, bin_ops::Add, bin_ops::FAdd},
+             {operand::sub, bin_ops::Sub, bin_ops::FSub},
+             {operand::mult, bin_ops::Mul, bin_ops::FMul},
+             {operand::div, bin_ops::SDiv, bin_ops::FDiv},
+             }
+        };
 
         const auto * selected_op
             = find_in(arithmetic_ops, [op = binary_operation.op](auto & entry) -> bool {

--- a/src/cfg_to_llvm.hpp
+++ b/src/cfg_to_llvm.hpp
@@ -47,6 +47,7 @@ class cfg_to_llvm final : public control_flow::visitor {
 
         node_data(llvm::IRBuilderBase & builder, llvm::Value * val);
     };
+
     // clang-format on
 
     void bind_value(const control_flow::node & node, llvm::Value * value);

--- a/src/cfg_to_llvm.hpp
+++ b/src/cfg_to_llvm.hpp
@@ -1,5 +1,4 @@
-#ifndef CFG_TO_LLVM_HPP
-#define CFG_TO_LLVM_HPP
+#pragma once
 
 #include "control_flow/node_forward.hpp"
 #include "control_flow/visitor.hpp"
@@ -69,5 +68,3 @@ class cfg_to_llvm final : public control_flow::visitor {
     std::unordered_set<const control_flow::node *> visited;
     scoped_map<std::string, llvm::Value *> local_names;
 };
-
-#endif

--- a/src/common/literal_type.hpp
+++ b/src/common/literal_type.hpp
@@ -1,4 +1,3 @@
-#ifndef LITERAL_TYPE_HPP
-#define LITERAL_TYPE_HPP
+#pragma once
+
 enum class literal_type { null, identifier, integer, floating, character, boolean, string };
-#endif

--- a/src/common/operations.hpp
+++ b/src/common/operations.hpp
@@ -1,5 +1,4 @@
-#ifndef COMMON_OPERATIONS_HPP
-#define COMMON_OPERATIONS_HPP
+#pragma once
 
 namespace operation {
     enum class binary {
@@ -52,5 +51,3 @@ namespace operation {
 
     enum class unary { bool_not, negate, deref };
 } // namespace operation
-
-#endif

--- a/src/common/token_to_string.hpp
+++ b/src/common/token_to_string.hpp
@@ -1,5 +1,4 @@
-#ifndef TOKEN_TO_STRING_HPP
-#define TOKEN_TO_STRING_HPP
+#pragma once
 
 #include "literal_type.hpp"
 #include "operations.hpp"
@@ -11,5 +10,3 @@
 [[nodiscard]] std::string token_to_string(operation::binary /*op*/);
 [[nodiscard]] std::string token_to_string(operation::unary /*op*/);
 [[nodiscard]] std::string token_to_string(literal_type /*op*/);
-
-#endif

--- a/src/control_flow/graph.hpp
+++ b/src/control_flow/graph.hpp
@@ -1,5 +1,4 @@
-#ifndef GRAPH_HPP
-#define GRAPH_HPP
+#pragma once
 
 #include <memory> // unique_ptr
 #include <vector>
@@ -74,5 +73,3 @@ namespace control_flow {
         node * previously_created{nullptr};
     };
 } // namespace control_flow
-
-#endif

--- a/src/control_flow/node.hpp
+++ b/src/control_flow/node.hpp
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <memory>
 #ifdef DEBUG
-#include <iostream>
+    #include <iostream>
 #endif
 #include <string>
 #include <variant>

--- a/src/control_flow/node.hpp
+++ b/src/control_flow/node.hpp
@@ -1,5 +1,4 @@
-#ifndef NODE_HPP
-#define NODE_HPP
+#pragma once
 
 #include "ast/type.hpp"
 #include "common/operations.hpp"
@@ -233,5 +232,3 @@ namespace control_flow {
 #undef make_visitable
 
 } // namespace control_flow
-
-#endif

--- a/src/control_flow/node_forward.hpp
+++ b/src/control_flow/node_forward.hpp
@@ -1,5 +1,4 @@
-#ifndef NODE_FORWARD_HPP
-#define NODE_FORWARD_HPP
+#pragma once
 
 // clang-format off
 #define all_cfg_nodes                    \
@@ -22,5 +21,3 @@ namespace control_flow {
     all_cfg_nodes
 #undef expand_node_macro
 } // namespace control_flow
-
-#endif

--- a/src/control_flow/serializer.cpp
+++ b/src/control_flow/serializer.cpp
@@ -59,9 +59,11 @@ namespace control_flow {
         auto [result, index] = add_node(&function_start);
         if (result == nullptr) { return value_getter::store_result(index); }
 
-        *result = {{"arg count", function_start.arg_count},
-                   {"exported", function_start.exported},
-                   {"next", get_value(*function_start.next, *this)}};
+        *result = {
+            {"arg count", function_start.arg_count},
+            {"exported", function_start.exported},
+            {"next", get_value(*function_start.next, *this)}
+        };
         return store_result(result);
     }
 
@@ -72,7 +74,9 @@ namespace control_flow {
         auto value = nlohmann::json{};
         if (function_end.value != nullptr) { value = get_value(*function_end.value, *this); }
 
-        *result = {{"value", std::move(value)}};
+        *result = {
+            {"value", std::move(value)}
+        };
         return store_result(result);
     }
 
@@ -80,10 +84,12 @@ namespace control_flow {
         auto [result, index] = add_node(&binary_operation);
         if (result == nullptr) { return value_getter::store_result(index); }
 
-        *result = {{"next", get_value(*binary_operation.next, *this)},
-                   {"left", get_value(*binary_operation.lhs, *this)},
-                   {"right", get_value(*binary_operation.rhs, *this)},
-                   {"op", token_to_string(binary_operation.op)}};
+        *result = {
+            {"next", get_value(*binary_operation.next, *this)},
+            {"left", get_value(*binary_operation.lhs, *this)},
+            {"right", get_value(*binary_operation.rhs, *this)},
+            {"op", token_to_string(binary_operation.op)}
+        };
         return store_result(result);
     }
 
@@ -92,9 +98,9 @@ namespace control_flow {
         if (result == nullptr) { return value_getter::store_result(index); }
 
         *result = {
-            {"condition", get_value(*branch.condition_value, *this)},
-            {"true case", get_value(*branch.true_case, *this)},
-            {"false case", get_value(*branch.false_case, *this)},
+            {"condition",  get_value(*branch.condition_value, *this)},
+            {"true case",  get_value(*branch.true_case,       *this)},
+            {"false case", get_value(*branch.false_case,      *this)},
         };
         return store_result(result);
     }
@@ -114,9 +120,11 @@ namespace control_flow {
             },
             constant.value);
 
-        *result = {{"value", std::move(value)},
-                   {"type", token_to_string(constant.val_type)},
-                   {"next", get_value(*constant.next, *this)}};
+        *result = {
+            {"value", std::move(value)},
+            {"type", token_to_string(constant.val_type)},
+            {"next", get_value(*constant.next, *this)}
+        };
         return store_result(result);
     }
 
@@ -127,9 +135,11 @@ namespace control_flow {
         nlohmann::json::array_t args;
         for (auto * arg : function_call.arguments) { args.push_back(get_value(*arg, *this)); }
 
-        *result = {{"next", get_value(*function_call.next, *this)},
-                   {"arguments", std::move(args)},
-                   {"callee", function_call.callee->name}};
+        *result = {
+            {"next", get_value(*function_call.next, *this)},
+            {"arguments", std::move(args)},
+            {"callee", function_call.callee->name}
+        };
         return store_result(result);
     }
 
@@ -140,9 +150,11 @@ namespace control_flow {
         nlohmann::json::array_t args;
         for (auto * arg : intrinsic_call.arguments) { args.push_back(get_value(*arg, *this)); }
 
-        *result = {{"next", get_value(*intrinsic_call.next, *this)},
-                   {"arguments", std::move(args)},
-                   {"callee", intrinsic_call.name}};
+        *result = {
+            {"next", get_value(*intrinsic_call.next, *this)},
+            {"arguments", std::move(args)},
+            {"callee", intrinsic_call.name}
+        };
         return store_result(result);
     }
 
@@ -184,9 +196,11 @@ namespace control_flow {
         auto [result, index] = add_node(&unary_operation);
         if (result == nullptr) { return value_getter::store_result(index); }
 
-        *result = {{"next", get_value(*unary_operation.next, *this)},
-                   {"op", token_to_string(unary_operation.op)},
-                   {"operand", get_value(*unary_operation.operand, *this)}};
+        *result = {
+            {"next", get_value(*unary_operation.next, *this)},
+            {"op", token_to_string(unary_operation.op)},
+            {"operand", get_value(*unary_operation.operand, *this)}
+        };
         return store_result(result);
     }
 } // namespace control_flow

--- a/src/control_flow/serializer.hpp
+++ b/src/control_flow/serializer.hpp
@@ -1,5 +1,4 @@
-#ifndef CFG_SERIALIZER_HPP
-#define CFG_SERIALIZER_HPP
+#pragma once
 
 #include "node_forward.hpp"
 #include "utils/value_getter.hpp"
@@ -36,5 +35,3 @@ namespace control_flow {
         std::map<node *, size_t> visited;
     };
 } // namespace control_flow
-
-#endif

--- a/src/control_flow/serializer.hpp
+++ b/src/control_flow/serializer.hpp
@@ -8,7 +8,9 @@
 
 namespace control_flow {
     /// The value returned is actually an index into the result vector.
-    class serializer final : public visitor, public value_getter<serializer, node, size_t> {
+    class serializer final
+        : public visitor
+        , public value_getter<serializer, node, size_t> {
       public:
         static void into_stream(std::ostream & stream, const std::vector<node *> & roots,
                                 bool human_readable);

--- a/src/control_flow/type_checker.hpp
+++ b/src/control_flow/type_checker.hpp
@@ -1,5 +1,4 @@
-#ifndef CFG_TYPE_CHECKER_HPP
-#define CFG_TYPE_CHECKER_HPP
+#pragma once
 
 #include "ast/type_context.hpp"
 #include "control_flow/visitor.hpp"
@@ -47,5 +46,3 @@ namespace control_flow {
         bool has_seen_error{false};
     };
 } // namespace control_flow
-
-#endif

--- a/src/control_flow/visitor.hpp
+++ b/src/control_flow/visitor.hpp
@@ -1,6 +1,5 @@
 
-#ifndef VISITOR_HPP
-#define VISITOR_HPP
+#pragma once
 
 #include "node_forward.hpp"
 
@@ -28,4 +27,3 @@ namespace control_flow {
     };
 
 } // namespace control_flow
-#endif

--- a/src/emit_asm.hpp
+++ b/src/emit_asm.hpp
@@ -1,5 +1,4 @@
-#ifndef EMIT_ASM_HPP
-#define EMIT_ASM_HPP
+#pragma once
 
 #include <memory>
 #include <string>
@@ -10,5 +9,3 @@
 
 void emit_asm(std::unique_ptr<llvm::Module> ir_module, std::string && output_filename,
               bool debug_optimized_ir);
-
-#endif

--- a/src/jit.hpp
+++ b/src/jit.hpp
@@ -1,10 +1,7 @@
-#ifndef JIT_HPP
-#define JIT_HPP
+#pragma once
 
 #include <memory> // unique_ptr
 
 #include <llvm/IR/Module.h>
 
 [[nodiscard]] uint64_t run_module(std::vector<std::unique_ptr<llvm::Module>> modules);
-
-#endif

--- a/src/llvm_type_lowering.hpp
+++ b/src/llvm_type_lowering.hpp
@@ -1,5 +1,4 @@
-#ifndef TYPE_CONTEXT_HPP
-#define TYPE_CONTEXT_HPP
+#pragma once
 
 #include "ast/node_utils.hpp"
 #include "ast/type_context.hpp"
@@ -20,5 +19,3 @@ class llvm_type_lowering final {
     global_map<std::string, ast::type_ptr> global_types;
     std::map<ast::type_ptr, llvm::Type *> active_types;
 };
-
-#endif

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -174,7 +174,8 @@ std::unique_ptr<program> program::from_root_file(const std::string & root_filena
 
     return std::unique_ptr<program>{
         new program{std::move(modules), std::move(ty_context), std::move(settings),
-                    normalized_absolute_path(root_filename).parent_path()}};
+                    normalized_absolute_path(root_filename).parent_path()}
+    };
 }
 
 program::~program() noexcept = default;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -1,5 +1,4 @@
-#ifndef PROGRAM_HPP
-#define PROGRAM_HPP
+#pragma once
 
 #include "ast/top_lvl_nodes.hpp"
 #include "ast/type_context.hpp"
@@ -52,5 +51,3 @@ class program final {
     std::unique_ptr<ast::type_context> ty_context;
     llvm_type_lowering llvm_lowering;
 };
-
-#endif

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -1,5 +1,4 @@
-#ifndef SETTINGS_HPP
-#define SETTINGS_HPP
+#pragma once
 
 #include <memory>
 #include <string>
@@ -34,5 +33,3 @@ struct Settings {
 // Parse all CLI arguments before the "--".
 // This allows `littlec myfile.lil -- --myflag` to pass `--myflag` to the resulting executable.
 std::shared_ptr<Settings> read_settings(int arg_count, const char * const * args);
-
-#endif

--- a/src/utils/execute.hpp
+++ b/src/utils/execute.hpp
@@ -1,10 +1,7 @@
-#ifndef EXECUTE_HPP
-#define EXECUTE_HPP
+#pragma once
 
 #include <string>
 #include <vector>
 
 // Returns `false` on any error.
 [[nodiscard]] bool exec_command(std::vector<std::string> && cmd, bool debug);
-
-#endif

--- a/src/utils/global_map.hpp
+++ b/src/utils/global_map.hpp
@@ -1,5 +1,4 @@
-#ifndef GLOBAL_VALUES_HPP
-#define GLOBAL_VALUES_HPP
+#pragma once
 
 #include <cassert>
 #include <map>
@@ -63,5 +62,3 @@ class global_map final {
         return lhs << '}';
     }
 };
-
-#endif

--- a/src/utils/move_copy.hpp
+++ b/src/utils/move_copy.hpp
@@ -1,5 +1,4 @@
-#ifndef MOVE_COPY_HPP
-#define MOVE_COPY_HPP
+#pragma once
 
 #define movable(type)        \
     type(type &&) = default; \
@@ -12,5 +11,3 @@
 #define non_copyable(type)       \
     type(const type &) = delete; \
     type & operator=(const type &) = delete
-
-#endif

--- a/src/utils/scoped_map.hpp
+++ b/src/utils/scoped_map.hpp
@@ -11,9 +11,11 @@ class scoped_map final {
 
     // Iterate thru the scopes in reverse
     [[nodiscard]] auto begin() noexcept { return active_values.rbegin(); }
+
     [[nodiscard]] auto end() noexcept { return active_values.rend(); }
 
     [[nodiscard]] auto begin() const noexcept { return active_values.rbegin(); }
+
     [[nodiscard]] auto end() const noexcept { return active_values.rend(); }
 
     auto add_to_root(key_t key, value_t value) {

--- a/src/utils/scoped_map.hpp
+++ b/src/utils/scoped_map.hpp
@@ -1,5 +1,4 @@
-#ifndef SCOPED_MAP_HPP
-#define SCOPED_MAP_HPP
+#pragma once
 
 #include <list>
 #include <map>
@@ -33,5 +32,3 @@ class scoped_map final {
     // `list` is prefered to `vector`, due to the former never indirectly invalidating iterators.
     std::list<std::map<key_t, value_t>> active_values;
 };
-
-#endif

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -11,6 +11,7 @@ std::string unquote(const std::string & input) {
 }
 
 namespace fs = std::filesystem;
+
 fs::path normalized_absolute_path(const std::string & relative_path) {
 
     return fs::canonical(fs::current_path() / relative_path);

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -1,10 +1,7 @@
-#ifndef STRING_UTILS_HPP
-#define STRING_UTILS_HPP
+#pragma once
 
 #include <filesystem>
 #include <string>
 
 std::string unquote(const std::string & /*input*/);
 std::filesystem::path normalized_absolute_path(const std::string & /*input*/);
-
-#endif

--- a/src/utils/value_getter.hpp
+++ b/src/utils/value_getter.hpp
@@ -1,5 +1,4 @@
-#ifndef VALUE_GETTER_HPP
-#define VALUE_GETTER_HPP
+#pragma once
 
 #include <cassert>
 #include <optional>
@@ -50,5 +49,3 @@ class value_getter {
   private:
     std::optional<result_t> result;
 };
-
-#endif

--- a/src/utils/value_getter.hpp
+++ b/src/utils/value_getter.hpp
@@ -17,6 +17,7 @@ template<typename visitor_t, typename visitable_t, typename result_t>
 class value_getter {
   public:
     static_assert(std::is_class_v<visitable_t>, "we must visit classes");
+
     [[nodiscard]] static result_t get_value(visitable_t & node, visitor_t & context) {
         assert(not context.result.has_value());
         node.accept(context);
@@ -24,6 +25,7 @@ class value_getter {
     }
 
     static_assert(not std::is_reference_v<result_t>, "we can only return non-references");
+
     void store_result(result_t value) {
         assert(not result.has_value());
         result = value;

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,5 +1,4 @@
-#ifndef VERSION_HPP
-#define VERSION_HPP
+#pragma once
 
 // clang-format off
 
@@ -9,4 +8,3 @@ namespace version {
     constexpr auto minor = @PROJECT_VERSION_MINOR@;
 } // namespace version
 
-#endif


### PR DESCRIPTION
This PR cleans up formatting by 
1. specifying more rules for clang-format
2. Switching over to `#pragma once`, which (while non-standard) most compilers agree to use